### PR TITLE
Add dilution and boil off gravity calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can now run it with:
 - **src** - The folder containing all source code
   - **calculators** - The folder containing subcommands for performing calculations
     - **abv.rs** - The file containing the subcommand `abv`
+    - **boil_off.rs** - The file containing the subcommand `boil_off`
     - **mod.rs** - The file defining the names of the structures used within the folder
     - **priming.rs** - The file containing the subcommand `priming`
     - **sg_correction.rs** - The file containing the subcommand `sg_correction`
@@ -35,7 +36,7 @@ Below is a table of the features currently implemented.
 Implemented                   | Function      | Description                                    | Usage
 ------------------------------|---------------|------------------------------------------------|-------
 :white_check_mark:            | ABV           | Calculates ABV from original and final gravity | `abv --og <Original gravity> --fg <Final gravity>`
-:negative_squared_cross_mark: | Boil-off      | Calculates the volume needed to be boiled down to for a desired SG | TDB
+:hourglass_flowing_sand:      | Boil-off Gravity| Calculates the volume needed to be boiled down to for a desired SG | `boil_off --current_gravity <current_gravity> --wort_volume <wort_volume> <--target_volume <target_volume>|--desired_gravity <desired_gravity>>`
 :white_check_mark:            | Dilution      | Calculates the SG after dilution | `diluting --sg <Current specific gravity> --cv <Current volume> --tv <Target volume>`
 :white_check_mark:            | Priming       | Beer Priming Calculator                        | `priming --temp <Beer temperature> --amount <Beer volume> --co2_volumes <co2_volumes>`
 :white_check_mark:            | SG Correction | Corrects SG reading according to the difference between the measurement temperature and the calibration temperature | `sg_correction --sg <Specific gravity reading> --ct <Calibration temperature> --mt <Measurement temperature>`

--- a/src/calculators/boil_off.rs
+++ b/src/calculators/boil_off.rs
@@ -1,0 +1,74 @@
+extern crate clap;
+use clap::{App, Arg, SubCommand, ArgMatches, ArgGroup, ErrorKind};
+use crate::AppSubCommand;
+
+pub struct BoilOff;
+
+impl AppSubCommand for BoilOff {
+    fn add_subcommand<'a, 'b>(&self, app: App<'a, 'b>) -> App<'a, 'b>{
+        app.subcommand(SubCommand::with_name("boil_off")
+            .version("0.1")
+            .about("Calculates how much you need to dilute or boil down your wort volume to hit a certain gravity")
+            .arg(Arg::with_name("wort_volume")
+                    .long("wort_volume")
+                    .short("w")
+                    .help("Wort Volume")
+                    .required(true)
+                    .takes_value(true))
+            .arg(Arg::with_name("current_gravity")
+                    .long("current_gravity")
+                    .short("c")
+                    .help("Current Gravity")
+                    .required(true)
+                    .takes_value(true))
+            .arg(Arg::with_name("desired_gravity")
+                    .long("desired_gravity")
+                    .short("d")
+                    .help("Desired Gravity")
+                    .takes_value(true))
+            .arg(Arg::with_name("target_volume")
+                    .long("target_volume")
+                    .short("t")
+                    .help("Target Volume")
+                    .takes_value(true))
+            .group(ArgGroup::with_name("desired")
+                    .args(&["target_volume", "desired_gravity"])
+                    .required(true))
+        )
+    }
+
+    fn do_matches<'c>(&self, matches: &ArgMatches<'c>){
+        if let Some(ref sub_matches) = matches.subcommand_matches("boil_off") {
+            let wort_volume = value_t!(sub_matches, "wort_volume", f32).unwrap_or_else(|e| e.exit());
+            let current_gravity = value_t!(sub_matches, "current_gravity", f32).unwrap_or_else(|e| e.exit());
+
+            println!("Wort Volume: {}", wort_volume);
+            println!("Current Gravity: {}", current_gravity);
+
+            match value_t!(sub_matches, "desired_gravity", f32) {
+                Ok(desired_gravity) => {
+                    let new_volume = self.calculate_boileoff_new_volume(wort_volume, current_gravity, desired_gravity);
+                    println!("New Volume: {}", new_volume);
+                    println!("Difference: {}", new_volume - wort_volume);
+                },
+                Err(ref e) if e.kind == clap::ErrorKind::ArgumentNotFound => {
+                    let target_volume = value_t!(sub_matches, "target_volume", f32).unwrap_or_else(|er| er.exit());
+                    let new_gravity = self.calculate_boileoff_new_gravity(wort_volume, current_gravity, target_volume);
+                    println!("New Gravity: {}", new_gravity);
+                    println!("Difference: {}", new_gravity - current_gravity);
+                },
+                Err(e) => e.exit()
+            }
+        }
+    }
+}
+
+impl BoilOff {
+    fn calculate_boileoff_new_volume(&self, wv: f32, cg: f32, dg: f32) -> f32 {
+        ((cg-1.0) / (dg-1.0)) * wv
+    }
+
+    fn calculate_boileoff_new_gravity(&self, wv: f32, cg: f32, tv: f32) -> f32 {
+        (cg-1.0) * (wv / tv) + 1.0
+    }
+}

--- a/src/calculators/mod.rs
+++ b/src/calculators/mod.rs
@@ -1,4 +1,5 @@
 pub mod abv;
+pub mod boil_off;
 pub mod diluting;
 pub mod priming;
 pub mod sg_correction;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() {
     // Add subcommands here
     let mut commands = ListOfSubCommands::new();
     commands.push(calculators::abv::Abv);
+    commands.push(calculators::boil_off::BoilOff);
     commands.push(calculators::diluting::Diluting);
     commands.push(calculators::priming::Priming);
     commands.push(calculators::sg_correction::SgCorrection);


### PR DESCRIPTION
The calculator supports the two cases, one when the new volume is unknown, and the case when the new gravity is unknown. Arguments are added to an ArgGroup so either desired gravity or target volume can be specified at the same time.

Should fix #12 

Signed-off-by: Mohammed Abdellatif <m.latief@gmail.com>