### PR TITLE
Improve conversion handling with Regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 clap = "2.33.*"
 measurements = "0.2.1"
+regex = "1"

--- a/src/calculators/num_bottles.rs
+++ b/src/calculators/num_bottles.rs
@@ -1,11 +1,10 @@
-use crate::utils::conversions::VolumeBuilder; // Converts string input to unit measurements
 /// A struct used to print how many bottles are needed to contain a given volume (in mL or L)
 pub struct NumBottles;
 
 impl NumBottles {
     // A function to store the different bottle types.
     // Can be extended as needed
-    fn bottles(&self) -> Vec<(String, f32)> {
+    fn bottles(&self) -> Vec<(String, f64)> {
         vec![
             ("330ml bottle".to_string(), 330.0),
             ("Twelve ounce bottle".to_string(), 355.0),
@@ -23,12 +22,11 @@ impl NumBottles {
     /// Prints out the quantity of bottles needed to store a given volume
     ///
     /// # Arguments
-    /// * 'volume' - A string of the volume to hold, with units appended e.g "10:mL", "5.4:gal", "3.99:L" etc.
+    /// * 'volume' - A volume to bottle in milliliters
     ///
-    pub fn calculate_num_bottles(&self, volume: String) -> Vec<(String, i32)> {
+    pub fn calculate_num_bottles(&self, volume: f64) -> Vec<(String, i32)> {
         let bottle_types = self.bottles();
         let mut bottle_counter: Vec<(String, i32)> = Vec::with_capacity(bottle_types.len());
-        let volume = VolumeBuilder::from_str(volume).unwrap().as_milliliters() as f32;
 
         for bottle in bottle_types {
             let num_bottles: i32 = ((volume) / bottle.1).ceil() as i32;
@@ -57,10 +55,7 @@ mod tests {
             ("Gallon jug".to_string(), 1),
             ("5 liter mini keg".to_string(), 1),
         ];
-        assert_eq!(
-            expected,
-            NumBottles.calculate_num_bottles("330:ml".to_string())
-        );
+        assert_eq!(expected, NumBottles.calculate_num_bottles(330.0));
     }
 
     #[test]
@@ -78,9 +73,6 @@ mod tests {
             ("Gallon jug".to_string(), 88),
             ("5 liter mini keg".to_string(), 66),
         ];
-        assert_eq!(
-            expected,
-            NumBottles.calculate_num_bottles("330:l".to_string())
-        );
+        assert_eq!(expected, NumBottles.calculate_num_bottles(330000.0));
     }
 }

--- a/src/commands/num_bottles.rs
+++ b/src/commands/num_bottles.rs
@@ -1,5 +1,6 @@
 extern crate clap;
 pub use crate::calculators::num_bottles::NumBottles;
+use crate::utils::conversions::VolumeBuilder; // Converts string input to unit measurements
 use crate::AppSubCommand;
 use clap::{value_t, App, Arg, ArgMatches, SubCommand};
 
@@ -27,9 +28,10 @@ impl AppSubCommand for NumBottles {
     fn do_matches<'a>(&self, matches: &ArgMatches<'a>) {
         if let Some(ref matches) = matches.subcommand_matches("num_bottles") {
             let vol = value_t!(matches, "volume", String).unwrap_or_else(|e| e.exit());
+            let volume = VolumeBuilder::from_str(&vol).unwrap().as_milliliters();
             println!("Volume to contain: {}", vol);
             println!("=======================================================");
-            let bottles = self.calculate_num_bottles(vol);
+            let bottles = self.calculate_num_bottles(volume);
             for bottle in bottles {
                 let output = format!(
                     "Type: {0: <20} | Quantity required: {1: <5} |",

--- a/src/commands/priming.rs
+++ b/src/commands/priming.rs
@@ -36,12 +36,10 @@ impl AppSubCommand for Priming {
             let co2_volumes =
                 value_t!(sub_matches, "co2_volumes", f64).unwrap_or_else(|e| e.exit());
 
-            let fahrenheit = TemperatureBuilder::from_str(temperature.clone())
+            let fahrenheit = TemperatureBuilder::from_str(&temperature)
                 .unwrap()
                 .as_fahrenheit();
-            let amount = VolumeBuilder::from_str(amount_str.clone())
-                .unwrap()
-                .as_litres();
+            let amount = VolumeBuilder::from_str(&amount_str).unwrap().as_litres();
             let co2_beer = self.calculate_co2(fahrenheit);
             let sugars = self.calculate_sugars(fahrenheit, amount, co2_volumes);
 

--- a/src/commands/sg_correction.rs
+++ b/src/commands/sg_correction.rs
@@ -38,11 +38,11 @@ impl AppSubCommand for SgCorrection {
         if let Some(ref matches) = matches.subcommand_matches("sg_correction") {
             let sg = value_t!(matches, "sg", f64).unwrap_or_else(|e| e.exit());
             let ct_str = value_t!(matches, "ct", String).unwrap_or_else(|e| e.exit());
-            let ct = TemperatureBuilder::from_str(ct_str.clone())
+            let ct = TemperatureBuilder::from_str(&ct_str)
                 .unwrap()
                 .as_fahrenheit();
             let mt_str = value_t!(matches, "mt", String).unwrap_or_else(|e| e.exit());
-            let mt = TemperatureBuilder::from_str(mt_str.clone())
+            let mt = TemperatureBuilder::from_str(&mt_str)
                 .unwrap()
                 .as_fahrenheit();
 

--- a/src/utils/conversions.rs
+++ b/src/utils/conversions.rs
@@ -3,77 +3,83 @@ use std::num::ParseFloatError;
 
 use measurements::{Temperature, Volume};
 
+/// Used to build new measurements::Temperature structs.
+///
+/// To be removed if the dependency some time allows creating measurement units from
+/// strings.
 pub struct TemperatureBuilder;
 
 impl TemperatureBuilder {
+    /// Creates measurements::Temperature from string
+    ///
+    /// Tries to figure out the temperature unit from the string. If the string value is plain
+    /// number, it will be considered as Celsius. Also empty strings are considered as
+    /// zero Celsius in Temperature.
     pub fn from_str(val: &str) -> Result<measurements::Temperature, ParseFloatError> {
         if val.is_empty() {
             return Ok(Temperature::from_celsius(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Z]{1})$").unwrap();
-        let capture = re.captures(val);
-        if capture.is_none() {
-            return Ok(Temperature::from_celsius(val.parse::<f64>()?));
+        if let Some(caps) = re.captures(val) {
+            let float_val = caps.get(1).unwrap().as_str();
+            return Ok(
+                match caps.get(2).unwrap().as_str().to_uppercase().as_str() {
+                    "F" => Temperature::from_fahrenheit(float_val.parse::<f64>()?),
+                    "C" => Temperature::from_celsius(float_val.parse::<f64>()?),
+                    "K" => Temperature::from_kelvin(float_val.parse::<f64>()?),
+                    "R" => Temperature::from_rankine(float_val.parse::<f64>()?),
+                    _ => Temperature::from_celsius(val.parse::<f64>()?),
+                },
+            );
         }
 
-        let caps = capture.unwrap();
-        if caps.len() == 1 {
-            return Ok(Temperature::from_celsius(val.parse::<f64>()?));
-        }
-
-        let float_val = caps.get(1).unwrap().as_str();
-        Ok(
-            match caps.get(2).unwrap().as_str().to_uppercase().as_str() {
-                "F" => Temperature::from_fahrenheit(float_val.parse::<f64>()?),
-                "C" => Temperature::from_celsius(float_val.parse::<f64>()?),
-                "K" => Temperature::from_kelvin(float_val.parse::<f64>()?),
-                "R" => Temperature::from_rankine(float_val.parse::<f64>()?),
-                _ => Temperature::from_celsius(val.parse::<f64>()?),
-            },
-        )
+        Ok(Temperature::from_celsius(val.parse::<f64>()?))
     }
 }
 
+/// Used to build new measurements::Volume structs.
+///
+/// To be removed if the dependency some time allows creating measurement units from
+/// strings.
 pub struct VolumeBuilder;
 
 impl VolumeBuilder {
+    /// Creates measurements::Volume from string
+    ///
+    /// Tries to figure out the volume unit from the string. If the string value is plain
+    /// number, it will be considered as litres. Also empty strings are considered as
+    /// zero litres in Volume.
     pub fn from_str(val: &str) -> Result<measurements::Volume, ParseFloatError> {
         if val.is_empty() {
             return Ok(Volume::from_litres(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Z]{1,3}[0-9]{0,1})$").unwrap();
-        let capture = re.captures(val);
-        if capture.is_none() {
-            return Ok(Volume::from_litres(val.parse::<f64>()?));
+        if let Some(caps) = re.captures(val) {
+            let float_val = caps.get(1).unwrap().as_str();
+            return Ok(
+                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
+                    "cm3" => Volume::from_cubic_centimeters(float_val.parse::<f64>()?),
+                    "ft3" => Volume::from_cubic_feet(float_val.parse::<f64>()?),
+                    "yd3" => Volume::from_cubic_yards(float_val.parse::<f64>()?),
+                    "in3" => Volume::from_cubic_inches(float_val.parse::<f64>()?),
+                    "gal" => Volume::from_gallons(float_val.parse::<f64>()?),
+                    "cup" => Volume::from_cups(float_val.parse::<f64>()?),
+                    "tsp" => Volume::from_teaspoons(float_val.parse::<f64>()?),
+                    "ml" => Volume::from_milliliters(float_val.parse::<f64>()?),
+                    "m3" => Volume::from_cubic_meters(float_val.parse::<f64>()?),
+                    "μl" => Volume::from_drops(float_val.parse::<f64>()?),
+                    "dr" => Volume::from_drams(float_val.parse::<f64>()?),
+                    "l" => Volume::from_litres(float_val.parse::<f64>()?),
+                    "p" => Volume::from_pints(float_val.parse::<f64>()?),
+                    "ʒ" => Volume::from_pints(float_val.parse::<f64>()?),
+                    _ => Volume::from_litres(val.parse::<f64>()?),
+                },
+            );
         }
 
-        let caps = capture.unwrap();
-        if caps.len() == 1 {
-            return Ok(Volume::from_litres(val.parse::<f64>()?));
-        }
-
-        let float_val = caps.get(1).unwrap().as_str();
-        Ok(
-            match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                "cm3" => Volume::from_cubic_centimeters(float_val.parse::<f64>()?),
-                "ft3" => Volume::from_cubic_feet(float_val.parse::<f64>()?),
-                "yd3" => Volume::from_cubic_yards(float_val.parse::<f64>()?),
-                "in3" => Volume::from_cubic_inches(float_val.parse::<f64>()?),
-                "gal" => Volume::from_gallons(float_val.parse::<f64>()?),
-                "cup" => Volume::from_cups(float_val.parse::<f64>()?),
-                "tsp" => Volume::from_teaspoons(float_val.parse::<f64>()?),
-                "ml" => Volume::from_milliliters(float_val.parse::<f64>()?),
-                "m3" => Volume::from_cubic_meters(float_val.parse::<f64>()?),
-                "μl" => Volume::from_drops(float_val.parse::<f64>()?),
-                "dr" => Volume::from_drams(float_val.parse::<f64>()?),
-                "l" => Volume::from_litres(float_val.parse::<f64>()?),
-                "p" => Volume::from_pints(float_val.parse::<f64>()?),
-                "ʒ" => Volume::from_pints(float_val.parse::<f64>()?),
-                _ => Volume::from_litres(val.parse::<f64>()?),
-            },
-        )
+        Ok(Volume::from_litres(val.parse::<f64>()?))
     }
 }
 
@@ -173,6 +179,8 @@ mod tests {
             123.0,
             TemperatureBuilder::from_str("123").unwrap().as_celsius(),
         );
+
+        assert_almost_equal(123.0, VolumeBuilder::from_str("123").unwrap().as_litres());
     }
 
     #[test]


### PR DESCRIPTION
This way no need to add separator for volumes and also works if there is
spaces between the number and the unit