### PR TITLE
Fix order of parameters in diluting calc

### DIFF
--- a/src/calculators/diluting.rs
+++ b/src/calculators/diluting.rs
@@ -25,11 +25,11 @@ impl Diluting {
     }
 
     /// Calculates the new volume based off a current
-    /// volume, a current gravity, and a target gravity
+    /// gravity, a current volume, and a target gravity
     pub fn calculate_new_volume(
         &self,
-        current_volume: f32,
         current_gravity: f32,
+        current_volume: f32,
         target_gravity: f32,
     ) -> f32 {
         current_volume * (current_gravity - 1.) / (target_gravity - 1.)

--- a/tests/calculators.rs
+++ b/tests/calculators.rs
@@ -37,7 +37,6 @@ fn diluting() {
     assert!(2. - diluting.calculate_new_volume(2., 2., 2.) < f32::EPSILON);
 
     assert!(14. - diluting.calculate_new_volume(7., 5., 3.) < f32::EPSILON);
-
 }
 
 #[test]


### PR DESCRIPTION
Try to keep the same order in parameters when doing same kind of calculators