### PR TITLE
Rewrite more consistent float tests

### DIFF
--- a/rustybeer-util/Cargo.toml
+++ b/rustybeer-util/Cargo.toml
@@ -10,6 +10,4 @@ once_cell = "1.4.1"
 regex = "1.3.9"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.58"
-
-[dev-dependencies]
-average = "0.10"
+approx = "0.3.2"

--- a/rustybeer-util/src/conversions.rs
+++ b/rustybeer-util/src/conversions.rs
@@ -126,280 +126,230 @@ impl MassBuilder {
 #[cfg(test)]
 mod tests {
     use super::{MassBuilder, TemperatureBuilder, VolumeBuilder};
-    use average::assert_almost_eq;
-    const DELTA: f64 = 1e-5;
+    use crate::assert_relative_eq;
 
     #[test]
     fn fahrenheit_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123F").unwrap().as_fahrenheit(),
-            DELTA
+            TemperatureBuilder::new("123F")
+                .unwrap()
+                .as_fahrenheit(),
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 F").unwrap().as_fahrenheit(),
-            DELTA
+            TemperatureBuilder::new("123 F")
+                .unwrap()
+                .as_fahrenheit(),
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 f").unwrap().as_fahrenheit(),
-            DELTA
+            TemperatureBuilder::new("123 f")
+                .unwrap()
+                .as_fahrenheit(),
         );
     }
 
     #[test]
     fn celsius_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123C").unwrap().as_celsius(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 C").unwrap().as_celsius(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 c").unwrap().as_celsius(),
-            DELTA
         );
     }
 
     #[test]
     fn kelvin_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123K").unwrap().as_kelvin(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 K").unwrap().as_kelvin(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 k").unwrap().as_kelvin(),
-            DELTA
         );
     }
 
     #[test]
     fn rankine_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123R").unwrap().as_rankine(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 R").unwrap().as_rankine(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 r").unwrap().as_rankine(),
-            DELTA
         );
     }
 
     #[test]
     fn default_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123").unwrap().as_celsius(),
-            DELTA
         );
 
-        assert_almost_eq!(123.0, VolumeBuilder::new("123").unwrap().as_litres(), DELTA);
-        assert_almost_eq!(123.0, MassBuilder::new("123").unwrap().as_grams(), DELTA);
+        assert_relative_eq!(123.0, VolumeBuilder::new("123").unwrap().as_litres(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123").unwrap().as_grams(),);
     }
 
     #[test]
     fn zero_from_string() {
-        assert_almost_eq!(0., TemperatureBuilder::new("").unwrap().as_celsius(), DELTA);
-        assert_almost_eq!(0., VolumeBuilder::new("").unwrap().as_litres(), DELTA);
-        assert_almost_eq!(0., MassBuilder::new("").unwrap().as_grams(), DELTA);
+        assert_relative_eq!(0., TemperatureBuilder::new("").unwrap().as_celsius(),);
+        assert_relative_eq!(0., VolumeBuilder::new("").unwrap().as_litres());
+        assert_relative_eq!(0., MassBuilder::new("").unwrap().as_grams());
     }
 
     #[test]
     fn cubic_centimeters_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
-            VolumeBuilder::new("123cm3").unwrap().as_cubic_centimeters(),
-            DELTA
+            VolumeBuilder::new("123cm3")
+                .unwrap()
+                .as_cubic_centimeters(),
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             VolumeBuilder::new("123 cm3")
                 .unwrap()
                 .as_cubic_centimeters(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             VolumeBuilder::new("123 CM3")
                 .unwrap()
                 .as_cubic_centimeters(),
-            DELTA
         );
     }
 
     #[test]
     fn milliliters_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             VolumeBuilder::new("123ml").unwrap().as_milliliters(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             VolumeBuilder::new("123 ml").unwrap().as_milliliters(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             VolumeBuilder::new("123 ml").unwrap().as_milliliters(),
-            DELTA
         );
     }
 
     #[test]
     fn pints_from_string() {
-        assert_almost_eq!(123.0, VolumeBuilder::new("123p").unwrap().as_pints(), DELTA);
-        assert_almost_eq!(
-            123.0,
-            VolumeBuilder::new("123 p").unwrap().as_pints(),
-            DELTA
-        );
-        assert_almost_eq!(
-            123.0,
-            VolumeBuilder::new("123 P").unwrap().as_pints(),
-            DELTA
-        );
+        assert_relative_eq!(123.0, VolumeBuilder::new("123p").unwrap().as_pints(),);
+        assert_relative_eq!(123.0, VolumeBuilder::new("123 p").unwrap().as_pints(),);
+        assert_relative_eq!(123.0, VolumeBuilder::new("123 P").unwrap().as_pints(),);
     }
 
     #[test]
     fn micrograms_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123ug").unwrap().as_micrograms(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123 ug").unwrap().as_micrograms(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123μg").unwrap().as_micrograms(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123 μg").unwrap().as_micrograms(),
-            DELTA
         );
     }
 
     #[test]
     fn milligrams_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123mg").unwrap().as_milligrams(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123 mg").unwrap().as_milligrams(),
-            DELTA
         );
     }
 
     #[test]
     fn carats_from_string() {
-        assert_almost_eq!(123.0, MassBuilder::new("123ct").unwrap().as_carats(), DELTA);
-        assert_almost_eq!(
-            123.0,
-            MassBuilder::new("123 ct").unwrap().as_carats(),
-            DELTA
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123ct").unwrap().as_carats(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 ct").unwrap().as_carats(),);
     }
 
     #[test]
     fn grams_from_string() {
-        assert_almost_eq!(123.0, MassBuilder::new("123g").unwrap().as_grams(), DELTA);
-        assert_almost_eq!(123.0, MassBuilder::new("123 g").unwrap().as_grams(), DELTA);
+        assert_relative_eq!(123.0, MassBuilder::new("123g").unwrap().as_grams(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 g").unwrap().as_grams(),);
     }
 
     #[test]
     fn kilograms_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123kg").unwrap().as_kilograms(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123 kg").unwrap().as_kilograms(),
-            DELTA
         );
     }
 
     #[test]
     fn tonnes_from_string() {
-        assert_almost_eq!(123.0, MassBuilder::new("123T").unwrap().as_tonnes(), DELTA);
-        assert_almost_eq!(123.0, MassBuilder::new("123 T").unwrap().as_tonnes(), DELTA);
+        assert_relative_eq!(123.0, MassBuilder::new("123T").unwrap().as_tonnes(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 T").unwrap().as_tonnes(),);
     }
 
     #[test]
     fn grains_from_string() {
-        assert_almost_eq!(123.0, MassBuilder::new("123gr").unwrap().as_grains(), DELTA);
-        assert_almost_eq!(
-            123.0,
-            MassBuilder::new("123 gr").unwrap().as_grains(),
-            DELTA
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123gr").unwrap().as_grains(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 gr").unwrap().as_grains(),);
     }
 
     #[test]
     fn pennyweights_from_string() {
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123dwt").unwrap().as_pennyweights(),
-            DELTA
         );
-        assert_almost_eq!(
+        assert_relative_eq!(
             123.0,
             MassBuilder::new("123 dwt").unwrap().as_pennyweights(),
-            DELTA
         );
     }
 
     #[test]
     fn ounces_from_string() {
-        assert_almost_eq!(123.0, MassBuilder::new("123oz").unwrap().as_ounces(), DELTA);
-        assert_almost_eq!(
-            123.0,
-            MassBuilder::new("123 oz").unwrap().as_ounces(),
-            DELTA
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123oz").unwrap().as_ounces(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 oz").unwrap().as_ounces(),);
     }
 
     #[test]
     fn pounds_from_string() {
-        assert_almost_eq!(
-            123.0,
-            MassBuilder::new("123lbs").unwrap().as_pounds(),
-            DELTA
-        );
-        assert_almost_eq!(
-            123.0,
-            MassBuilder::new("123 lbs").unwrap().as_pounds(),
-            DELTA
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123lbs").unwrap().as_pounds(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 lbs").unwrap().as_pounds(),);
     }
 }

--- a/rustybeer-util/src/conversions.rs
+++ b/rustybeer-util/src/conversions.rs
@@ -126,36 +126,27 @@ impl MassBuilder {
 #[cfg(test)]
 mod tests {
     use super::{MassBuilder, TemperatureBuilder, VolumeBuilder};
-    use crate::assert_relative_eq;
+    use approx::assert_relative_eq;
 
     #[test]
     fn fahrenheit_from_string() {
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123F")
-                .unwrap()
-                .as_fahrenheit(),
+            TemperatureBuilder::new("123F").unwrap().as_fahrenheit(),
         );
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 F")
-                .unwrap()
-                .as_fahrenheit(),
+            TemperatureBuilder::new("123 F").unwrap().as_fahrenheit(),
         );
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 f")
-                .unwrap()
-                .as_fahrenheit(),
+            TemperatureBuilder::new("123 f").unwrap().as_fahrenheit(),
         );
     }
 
     #[test]
     fn celsius_from_string() {
-        assert_relative_eq!(
-            123.0,
-            TemperatureBuilder::new("123C").unwrap().as_celsius(),
-        );
+        assert_relative_eq!(123.0, TemperatureBuilder::new("123C").unwrap().as_celsius(),);
         assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 C").unwrap().as_celsius(),
@@ -168,26 +159,14 @@ mod tests {
 
     #[test]
     fn kelvin_from_string() {
-        assert_relative_eq!(
-            123.0,
-            TemperatureBuilder::new("123K").unwrap().as_kelvin(),
-        );
-        assert_relative_eq!(
-            123.0,
-            TemperatureBuilder::new("123 K").unwrap().as_kelvin(),
-        );
-        assert_relative_eq!(
-            123.0,
-            TemperatureBuilder::new("123 k").unwrap().as_kelvin(),
-        );
+        assert_relative_eq!(123.0, TemperatureBuilder::new("123K").unwrap().as_kelvin(),);
+        assert_relative_eq!(123.0, TemperatureBuilder::new("123 K").unwrap().as_kelvin(),);
+        assert_relative_eq!(123.0, TemperatureBuilder::new("123 k").unwrap().as_kelvin(),);
     }
 
     #[test]
     fn rankine_from_string() {
-        assert_relative_eq!(
-            123.0,
-            TemperatureBuilder::new("123R").unwrap().as_rankine(),
-        );
+        assert_relative_eq!(123.0, TemperatureBuilder::new("123R").unwrap().as_rankine(),);
         assert_relative_eq!(
             123.0,
             TemperatureBuilder::new("123 R").unwrap().as_rankine(),
@@ -200,10 +179,7 @@ mod tests {
 
     #[test]
     fn default_from_string() {
-        assert_relative_eq!(
-            123.0,
-            TemperatureBuilder::new("123").unwrap().as_celsius(),
-        );
+        assert_relative_eq!(123.0, TemperatureBuilder::new("123").unwrap().as_celsius(),);
 
         assert_relative_eq!(123.0, VolumeBuilder::new("123").unwrap().as_litres(),);
         assert_relative_eq!(123.0, MassBuilder::new("123").unwrap().as_grams(),);
@@ -220,9 +196,7 @@ mod tests {
     fn cubic_centimeters_from_string() {
         assert_relative_eq!(
             123.0,
-            VolumeBuilder::new("123cm3")
-                .unwrap()
-                .as_cubic_centimeters(),
+            VolumeBuilder::new("123cm3").unwrap().as_cubic_centimeters(),
         );
         assert_relative_eq!(
             123.0,
@@ -240,10 +214,7 @@ mod tests {
 
     #[test]
     fn milliliters_from_string() {
-        assert_relative_eq!(
-            123.0,
-            VolumeBuilder::new("123ml").unwrap().as_milliliters(),
-        );
+        assert_relative_eq!(123.0, VolumeBuilder::new("123ml").unwrap().as_milliliters(),);
         assert_relative_eq!(
             123.0,
             VolumeBuilder::new("123 ml").unwrap().as_milliliters(),
@@ -263,34 +234,16 @@ mod tests {
 
     #[test]
     fn micrograms_from_string() {
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123ug").unwrap().as_micrograms(),
-        );
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123 ug").unwrap().as_micrograms(),
-        );
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123μg").unwrap().as_micrograms(),
-        );
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123 μg").unwrap().as_micrograms(),
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123ug").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 ug").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123μg").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 μg").unwrap().as_micrograms(),);
     }
 
     #[test]
     fn milligrams_from_string() {
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123mg").unwrap().as_milligrams(),
-        );
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123 mg").unwrap().as_milligrams(),
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123mg").unwrap().as_milligrams(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 mg").unwrap().as_milligrams(),);
     }
 
     #[test]
@@ -307,14 +260,8 @@ mod tests {
 
     #[test]
     fn kilograms_from_string() {
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123kg").unwrap().as_kilograms(),
-        );
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123 kg").unwrap().as_kilograms(),
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123kg").unwrap().as_kilograms(),);
+        assert_relative_eq!(123.0, MassBuilder::new("123 kg").unwrap().as_kilograms(),);
     }
 
     #[test]
@@ -331,10 +278,7 @@ mod tests {
 
     #[test]
     fn pennyweights_from_string() {
-        assert_relative_eq!(
-            123.0,
-            MassBuilder::new("123dwt").unwrap().as_pennyweights(),
-        );
+        assert_relative_eq!(123.0, MassBuilder::new("123dwt").unwrap().as_pennyweights(),);
         assert_relative_eq!(
             123.0,
             MassBuilder::new("123 dwt").unwrap().as_pennyweights(),

--- a/rustybeer-util/src/hops.rs
+++ b/rustybeer-util/src/hops.rs
@@ -40,7 +40,7 @@ pub static HOPS: Lazy<Vec<Hop>> = Lazy::new(|| serde_json::from_str(HOPS_JSON).u
 #[cfg(test)]
 pub mod tests {
     use super::HOPS;
-    use crate::assert_relative_eq;
+    use approx::assert_relative_eq;
 
     #[test]
     fn centennial() {

--- a/rustybeer-util/src/hops.rs
+++ b/rustybeer-util/src/hops.rs
@@ -38,20 +38,18 @@ impl Hop {
 pub static HOPS: Lazy<Vec<Hop>> = Lazy::new(|| serde_json::from_str(HOPS_JSON).unwrap());
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use super::HOPS;
+    use crate::assert_relative_eq;
 
     #[test]
     fn centennial() {
-        assert!(
-            (0.095
-                - HOPS
-                    .iter()
-                    .find(|&h| h.name == "Centennial")
-                    .unwrap()
-                    .alpha_acid_min)
-                .abs()
-                < f64::EPSILON
+        assert_relative_eq!(
+            0.095,
+            HOPS.iter()
+                .find(|&h| h.name == "Centennial")
+                .unwrap()
+                .alpha_acid_min
         );
     }
 }

--- a/rustybeer-util/src/lib.rs
+++ b/rustybeer-util/src/lib.rs
@@ -6,3 +6,23 @@
 pub mod beer_styles;
 pub mod conversions;
 pub mod hops;
+
+#[macro_export]
+macro_rules! relative_eq_eps {
+    ($lhs:expr, $rhs:expr $(, $opt:ident = $val:expr)*) => {
+        approx::Relative::default().epsilon(1e-4)$(.$opt($val))*.eq(&$lhs, &$rhs)
+    };
+    ($lhs:expr, $rhs:expr $(, $opt:ident = $val:expr)*,) => {
+        approx::Relative::default().epsilon(1e-4)$(.$opt($val))*.eq(&$lhs, &$rhs)
+    };
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! assert_relative_eq {
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
+        approx::__assert_approx!(relative_eq_eps, $given, $expected $(, $opt = $val)*)
+    };
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
+        approx::__assert_approx!(relative_eq_eps, $given, $expected $(, $opt = $val)*)
+    };
+}

--- a/rustybeer-util/src/lib.rs
+++ b/rustybeer-util/src/lib.rs
@@ -7,22 +7,4 @@ pub mod beer_styles;
 pub mod conversions;
 pub mod hops;
 
-#[macro_export]
-macro_rules! relative_eq_eps {
-    ($lhs:expr, $rhs:expr $(, $opt:ident = $val:expr)*) => {
-        approx::Relative::default().epsilon(1e-4)$(.$opt($val))*.eq(&$lhs, &$rhs)
-    };
-    ($lhs:expr, $rhs:expr $(, $opt:ident = $val:expr)*,) => {
-        approx::Relative::default().epsilon(1e-4)$(.$opt($val))*.eq(&$lhs, &$rhs)
-    };
-}
-
-#[macro_export(local_inner_macros)]
-macro_rules! assert_relative_eq {
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
-        approx::__assert_approx!(relative_eq_eps, $given, $expected $(, $opt = $val)*)
-    };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        approx::__assert_approx!(relative_eq_eps, $given, $expected $(, $opt = $val)*)
-    };
-}
+mod macros;

--- a/rustybeer-util/src/macros.rs
+++ b/rustybeer-util/src/macros.rs
@@ -1,0 +1,11 @@
+/// Wrapper for `approx::assert_relative_eq` with `epsilon = 1e-4` as default
+/// since default epsilon used by `approx` is too accurate
+#[macro_export]
+macro_rules! assert_approx {
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
+        approx::assert_relative_eq!($given, $expected, epsilon = 1e-4 $(, $opt = $val)*)
+    };
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
+        approx::assert_relative_eq!($given, $expected, epsilon = 1e-4 $(, $opt = $val)*)
+    };
+}

--- a/rustybeer/Cargo.toml
+++ b/rustybeer/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-average = "0.10"
+approx = "0.3.2"
+rustybeer-util = { version = "0.1.0", path = "../rustybeer-util"}

--- a/rustybeer/src/calculators/ibu.rs
+++ b/rustybeer/src/calculators/ibu.rs
@@ -226,12 +226,13 @@ pub fn calculate_bittering_weight(
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use super::{
         calculate_bittering_weight, calculate_ibu, HopAddition, HopAdditionType, NegativeIbuError,
         _calculate_ibu_single_hop, _calculate_utilization,
     };
-    use average::assert_almost_eq;
+
+    use rustybeer_util::assert_relative_eq;
 
     #[test]
     fn utilization() {
@@ -239,24 +240,28 @@ pub mod test {
         for (og_idx, og) in test_vector.og.iter().enumerate() {
             for (boiling_time_idx, boiling_time) in test_vector.boiling_time.iter().enumerate() {
                 let ut = _calculate_utilization(*og, *boiling_time);
-                assert_almost_eq!(test_vector.utilization[boiling_time_idx][og_idx], ut, 0.001);
+                // Only three decimals provided in test vector
+                assert_relative_eq!(
+                    test_vector.utilization[boiling_time_idx][og_idx],
+                    ut,
+                    epsilon = 1e-3
+                );
             }
         }
     }
 
     #[test]
     fn single_hop_ibu() {
-        assert_almost_eq!(
-            2.88,
-            _calculate_ibu_single_hop(7.0, 0.085, 15, 22.0, 1.058, 1.),
-            0.01
+        assert_relative_eq!(
+            2.8808,
+            _calculate_ibu_single_hop(7.0, 0.085, 15, 22.0, 1.058, 1.)
         );
     }
 
     #[test]
     fn multiple_hops_ibu() {
-        assert_almost_eq!(
-            5.76,
+        assert_relative_eq!(
+            5.7615,
             calculate_ibu(
                 vec![
                     HopAddition::new(7.0, 0.085, 15, HopAdditionType::Whole),
@@ -265,15 +270,14 @@ pub mod test {
                 22.0,
                 1.058
             ),
-            0.01
         );
     }
 
     #[test]
     fn pellet_hops_ibu() {
         // 6.336 = 5.76 * 1.1
-        assert_almost_eq!(
-            6.336,
+        assert_relative_eq!(
+            6.3376,
             calculate_ibu(
                 vec![
                     HopAddition::new(7.0, 0.085, 15, HopAdditionType::Pellet),
@@ -282,7 +286,6 @@ pub mod test {
                 22.0,
                 1.058
             ),
-            0.01
         );
     }
 
@@ -307,7 +310,7 @@ pub mod test {
 
     #[test]
     fn bitter_hops_weight() -> Result<(), NegativeIbuError> {
-        assert_almost_eq!(
+        assert_relative_eq!(
             13.2611,
             calculate_bittering_weight(
                 Some(vec![
@@ -320,13 +323,12 @@ pub mod test {
                 1.058,
                 16.76,
             )?,
-            0.001
         );
         Ok(())
     }
 
     #[test]
     fn zero_hops_ibu() {
-        assert_almost_eq!(0., calculate_ibu(vec![], 22.0, 1.058), f64::EPSILON);
+        assert_relative_eq!(0., calculate_ibu(vec![], 22.0, 1.058));
     }
 }

--- a/rustybeer/src/calculators/ibu.rs
+++ b/rustybeer/src/calculators/ibu.rs
@@ -126,9 +126,9 @@ pub struct NegativeIbuError;
 /// * Cascade (6.4% AA): 28g - 45 mins
 ///
 /// ```
-/// use rustybeer::calculators::ibu::HopAddition;
-/// use rustybeer::calculators::ibu::calculate_ibu;
-/// assert!( (18.972_316 - calculate_ibu(vec![HopAddition::new(28.0, 0.064, 45, Default::default())], 20.0, 1.050)).abs() < 0.01);
+/// use rustybeer::calculators::ibu::{HopAddition, calculate_ibu};
+/// use rustybeer_util::assert_approx;
+/// assert_approx!(18.9723, calculate_ibu(vec![HopAddition::new(28.0, 0.064, 45, Default::default())], 20.0, 1.050));
 /// ```
 ///
 pub fn calculate_ibu(
@@ -175,8 +175,10 @@ pub fn calculate_ibu(
 /// * No other hops additions
 /// ```
 /// use rustybeer::calculators::ibu::calculate_bittering_weight;
+/// use rustybeer_util::assert_approx;
+///
 /// let bittering = calculate_bittering_weight(None, 0.085, None, 22., 1.058, 17.);
-/// assert!( (20.50 - bittering.unwrap()).abs() < 0.01);
+/// assert_approx!( 20.4973, bittering.unwrap());
 /// ```
 ///
 /// With addition of 20gm of Centennial (8.5% AA) for 60min boil,
@@ -231,8 +233,7 @@ pub mod tests {
         calculate_bittering_weight, calculate_ibu, HopAddition, HopAdditionType, NegativeIbuError,
         _calculate_ibu_single_hop, _calculate_utilization,
     };
-
-    use rustybeer_util::assert_relative_eq;
+    use rustybeer_util::assert_approx;
 
     #[test]
     fn utilization() {
@@ -241,7 +242,7 @@ pub mod tests {
             for (boiling_time_idx, boiling_time) in test_vector.boiling_time.iter().enumerate() {
                 let ut = _calculate_utilization(*og, *boiling_time);
                 // Only three decimals provided in test vector
-                assert_relative_eq!(
+                approx::assert_relative_eq!(
                     test_vector.utilization[boiling_time_idx][og_idx],
                     ut,
                     epsilon = 1e-3
@@ -252,7 +253,7 @@ pub mod tests {
 
     #[test]
     fn single_hop_ibu() {
-        assert_relative_eq!(
+        assert_approx!(
             2.8808,
             _calculate_ibu_single_hop(7.0, 0.085, 15, 22.0, 1.058, 1.)
         );
@@ -260,7 +261,7 @@ pub mod tests {
 
     #[test]
     fn multiple_hops_ibu() {
-        assert_relative_eq!(
+        assert_approx!(
             5.7615,
             calculate_ibu(
                 vec![
@@ -276,7 +277,7 @@ pub mod tests {
     #[test]
     fn pellet_hops_ibu() {
         // 6.336 = 5.76 * 1.1
-        assert_relative_eq!(
+        assert_approx!(
             6.3376,
             calculate_ibu(
                 vec![
@@ -310,7 +311,7 @@ pub mod tests {
 
     #[test]
     fn bitter_hops_weight() -> Result<(), NegativeIbuError> {
-        assert_relative_eq!(
+        assert_approx!(
             13.2611,
             calculate_bittering_weight(
                 Some(vec![
@@ -329,6 +330,6 @@ pub mod tests {
 
     #[test]
     fn zero_hops_ibu() {
-        assert_relative_eq!(0., calculate_ibu(vec![], 22.0, 1.058));
+        assert_approx!(0., calculate_ibu(vec![], 22.0, 1.058));
     }
 }

--- a/rustybeer/tests/calculators.rs
+++ b/rustybeer/tests/calculators.rs
@@ -1,47 +1,47 @@
-use rustybeer_util::assert_relative_eq;
+use rustybeer_util::assert_approx;
 
 #[test]
 fn abv() {
     use rustybeer::calculators::abv::calculate_abv;
 
-    assert_relative_eq!(1050., calculate_abv(10., 2.));
+    assert_approx!(1050., calculate_abv(10., 2.));
 
-    assert_relative_eq!(39.5548, calculate_abv(0.3026, 0.00123));
+    assert_approx!(39.5548, calculate_abv(0.3026, 0.00123));
 }
 
 #[test]
 fn boil_off() {
     use rustybeer::calculators::diluting::*;
 
-    assert_relative_eq!(2., calculate_new_volume(2., 2., 2.));
+    assert_approx!(2., calculate_new_volume(2., 2., 2.));
 
-    assert_relative_eq!(15., calculate_new_volume(7., 5., 3.));
+    assert_approx!(15., calculate_new_volume(7., 5., 3.));
 
-    assert_relative_eq!(11., calculate_new_gravity(7., 5., 3.));
+    assert_approx!(11., calculate_new_gravity(7., 5., 3.));
 
-    assert_relative_eq!(69.5714, calculate_new_gravity(4., 3.2, 0.14));
+    assert_approx!(69.5714, calculate_new_gravity(4., 3.2, 0.14));
 }
 
 #[test]
 fn diluting() {
     use rustybeer::calculators::diluting::*;
 
-    assert_relative_eq!(14.1625, calculate_new_gravity(9.1, 5.2, 3.2));
+    assert_approx!(14.1625, calculate_new_gravity(9.1, 5.2, 3.2));
 
-    assert_relative_eq!(4.5305, calculate_new_gravity(9.1, 3.16, 7.25));
+    assert_approx!(4.5305, calculate_new_gravity(9.1, 3.16, 7.25));
 
-    assert_relative_eq!(2.0, calculate_new_volume(2., 2., 2.));
+    assert_approx!(2.0, calculate_new_volume(2., 2., 2.));
 
-    assert_relative_eq!(15., calculate_new_volume(7., 5., 3.));
+    assert_approx!(15., calculate_new_volume(7., 5., 3.));
 }
 
 #[test]
 fn priming() {
     use rustybeer::calculators::priming::{calculate_co2, calculate_sugars, Sugar};
 
-    assert_relative_eq!(2.3466, calculate_co2(15.));
+    assert_approx!(2.3466, calculate_co2(15.));
 
-    assert_relative_eq!(2.4556, calculate_co2(12.45));
+    assert_approx!(2.4556, calculate_co2(12.45));
 
     let stream = calculate_sugars(77., 5., 2.);
 
@@ -72,9 +72,9 @@ fn priming() {
 fn sg_correction() {
     use rustybeer::calculators::sg_correction::correct_sg;
 
-    assert_relative_eq!(5.001, correct_sg(5.0, 2.9, 1.37));
+    assert_approx!(5.001, correct_sg(5.0, 2.9, 1.37));
 
-    assert_relative_eq!(7.3023, correct_sg(7.3, 8.1, 5.12));
+    assert_approx!(7.3023, correct_sg(7.3, 8.1, 5.12));
 
-    assert_relative_eq!(7.4175, correct_sg(7.413, 28.1, 55.1212));
+    assert_approx!(7.4175, correct_sg(7.413, 28.1, 55.1212));
 }

--- a/rustybeer/tests/calculators.rs
+++ b/rustybeer/tests/calculators.rs
@@ -1,45 +1,47 @@
+use rustybeer_util::assert_relative_eq;
+
 #[test]
 fn abv() {
     use rustybeer::calculators::abv::calculate_abv;
 
-    assert!((1050. - calculate_abv(10., 2.)).abs() < f32::EPSILON);
+    assert_relative_eq!(1050., calculate_abv(10., 2.));
 
-    assert!((39.554_813 - calculate_abv(0.3026, 0.00123)).abs() < f32::EPSILON)
+    assert_relative_eq!(39.5548, calculate_abv(0.3026, 0.00123));
 }
 
 #[test]
 fn boil_off() {
     use rustybeer::calculators::diluting::*;
 
-    assert!((2. - calculate_new_volume(2., 2., 2.)).abs() < f32::EPSILON);
+    assert_relative_eq!(2., calculate_new_volume(2., 2., 2.));
 
-    assert!((15. - calculate_new_volume(7., 5., 3.)).abs() < f32::EPSILON);
+    assert_relative_eq!(15., calculate_new_volume(7., 5., 3.));
 
-    assert!((8.309999 - calculate_new_gravity(18., 2.15, 5.)).abs() < f32::EPSILON);
+    assert_relative_eq!(11., calculate_new_gravity(7., 5., 3.));
 
-    assert!((69.57143 - calculate_new_gravity(4., 3.2, 0.14)).abs() < f32::EPSILON);
+    assert_relative_eq!(69.5714, calculate_new_gravity(4., 3.2, 0.14));
 }
 
 #[test]
 fn diluting() {
     use rustybeer::calculators::diluting::*;
 
-    assert!((14.162499 - calculate_new_gravity(9.1, 5.2, 3.2)).abs() < f32::EPSILON);
+    assert_relative_eq!(14.1625, calculate_new_gravity(9.1, 5.2, 3.2));
 
-    assert!((4.5304832 - calculate_new_gravity(9.1, 3.16, 7.25)).abs() < f32::EPSILON);
+    assert_relative_eq!(4.5305, calculate_new_gravity(9.1, 3.16, 7.25));
 
-    assert!((2. - calculate_new_volume(2., 2., 2.)).abs() < f32::EPSILON);
+    assert_relative_eq!(2.0, calculate_new_volume(2., 2., 2.));
 
-    assert!((15. - calculate_new_volume(7., 5., 3.)).abs() < f32::EPSILON);
+    assert_relative_eq!(15., calculate_new_volume(7., 5., 3.));
 }
 
 #[test]
 fn priming() {
     use rustybeer::calculators::priming::{calculate_co2, calculate_sugars, Sugar};
 
-    assert!((2.3466187499999998 - calculate_co2(15.)).abs() < f64::EPSILON);
+    assert_relative_eq!(2.3466, calculate_co2(15.));
 
-    assert!((2.4556890138750003 - calculate_co2(12.45)).abs() < f64::EPSILON);
+    assert_relative_eq!(2.4556, calculate_co2(12.45));
 
     let stream = calculate_sugars(77., 5., 2.);
 
@@ -70,9 +72,9 @@ fn priming() {
 fn sg_correction() {
     use rustybeer::calculators::sg_correction::correct_sg;
 
-    assert!((5.00096332765874 - correct_sg(5.0, 2.9, 1.37)).abs() < f64::EPSILON);
+    assert_relative_eq!(5.001, correct_sg(5.0, 2.9, 1.37));
 
-    assert!((7.3023498553759225 - correct_sg(7.3, 8.1, 5.12)).abs() < f64::EPSILON);
+    assert_relative_eq!(7.3023, correct_sg(7.3, 8.1, 5.12));
 
-    assert!((7.417526019059315 - correct_sg(7.413, 28.1, 55.1212)).abs() < f64::EPSILON);
+    assert_relative_eq!(7.4175, correct_sg(7.413, 28.1, 55.1212));
 }


### PR DESCRIPTION
Use `approx` and provide a convenient wrapper for `approx::assert_relative_eq` with epsilon larger than `approx` crate's default.