### PR TITLE
Use structopt for much nicer command line arguments parsing

### DIFF
--- a/rustybeer-cli/Cargo.toml
+++ b/rustybeer-cli/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Heikki Hellgren <heiccih@gmail.com>", "mlatief", "Joseph Russell"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 rustybeer = { version = "0.1.0", path = "../rustybeer"}
 rustybeer-util = { version = "0.1.0", path = "../rustybeer-util"}
 structopt = "0.3.20"

--- a/rustybeer-cli/Cargo.toml
+++ b/rustybeer-cli/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 rustybeer = { version = "0.1.0", path = "../rustybeer"}
 rustybeer-util = { version = "0.1.0", path = "../rustybeer-util"}
 structopt = "0.3.20"
-measurements = "0.10.3"
 
 [[bin]]
 name = "rustybeer"

--- a/rustybeer-cli/Cargo.toml
+++ b/rustybeer-cli/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 rustybeer = { version = "0.1.0", path = "../rustybeer"}
 rustybeer-util = { version = "0.1.0", path = "../rustybeer-util"}
-
-clap = "2.33.3"
+structopt = "0.3.20"
+measurements = "0.10.3"
 
 [[bin]]
 name = "rustybeer"

--- a/rustybeer-cli/src/commands/abv.rs
+++ b/rustybeer-cli/src/commands/abv.rs
@@ -1,47 +1,29 @@
-use clap::{value_t, App, Arg, ArgMatches};
-pub use rustybeer::calculators::abv::{calculate_abv, calculate_fg};
+use rustybeer::calculators::abv::{calculate_abv, calculate_fg};
+use structopt::StructOpt;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("abv")
-            .version("0.1")
-            .author("Heikki Hellgren (heiccih@gmail.com)")
-            .about("Calculates Alcohol By Volue (ABV) from original and final gravity or final gravity from original gravity and ABV")
-            .arg(Arg::with_name("og")
-                 .short("o")
-                 .long("og")
-                 .value_name("OG")
-                 .help("Original gravity")
-                 .required(true)
-                 .takes_value(true))
-            .arg(Arg::with_name("fg")
-                 .short("f")
-                 .long("fg")
-                 .value_name("FG")
-                 .help("Final gravity")
-                 .required_unless("abv")
-                 .takes_value(true))
-            .arg(Arg::with_name("abv")
-                 .short("a")
-                 .long("abv")
-                 .value_name("ABV")
-                 .help("Alcohol by volume")
-                 .required_unless("fg")
-                 .takes_value(true))
+#[derive(Debug, StructOpt)]
+#[structopt(name = "abv", author = "Heikki Hellgren (heiccih@gmail.com)")]
+/// Calculates Alcohol By Volume (ABV) from original and final gravity or final gravity from original gravity and ABV
+pub struct AbvOptions {
+    #[structopt(short, long)]
+    /// Original gravity
+    og: f32,
+
+    #[structopt(short, long, required_unless("abv"))]
+    /// Final gravity
+    fg: Option<f32>,
+
+    #[structopt(short, long, required_unless("fg"))]
+    /// Alcohol by volume
+    abv: Option<f32>,
 }
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("abv") {
-        if matches.is_present("fg") {
-            let fg = value_t!(matches, "fg", f32).unwrap_or_else(|e| e.exit());
-            let og = value_t!(matches, "og", f32).unwrap_or_else(|e| e.exit());
-            println!("ABV: {:.3}%", calculate_abv(og, fg));
-        } else if matches.is_present("abv") {
-            let og = value_t!(matches, "og", f32).unwrap_or_else(|e| e.exit());
-            let abv = value_t!(matches, "abv", f32).unwrap_or_else(|e| e.exit());
-            println!("FG: {:.3}", calculate_fg(og, abv));
-        } else {
-            println!("Either specify final gravity or abv!");
-            println!("{}", matches.usage());
-        }
+pub fn calculate_and_print(abv_options: AbvOptions) {
+    if let Some(fg) = abv_options.fg {
+        println!("ABV: {:.3}%", calculate_abv(abv_options.og, fg));
+    }
+
+    if let Some(abv) = abv_options.abv {
+        println!("ABV: {:.3}%", calculate_fg(abv_options.og, abv));
     }
 }

--- a/rustybeer-cli/src/commands/alcohol_volume_weight.rs
+++ b/rustybeer-cli/src/commands/alcohol_volume_weight.rs
@@ -1,94 +1,64 @@
-use clap::{value_t, App, Arg, ArgMatches};
 pub use rustybeer::calculators::alcohol_volume_weight::{
     calculate_abv_abw, calculate_abv_abw_density, calculate_abw_abv, calculate_abw_abv_density,
     calculate_alc_vol, calculate_alc_weight,
 };
-use rustybeer_util::conversions::VolumeBuilder;
+use rustybeer_util::{conversions::VolumeParser, measurements::Volume};
+use structopt::StructOpt;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("abv_abw")
-        .version("0.1")
-        .author("Joseph Russell (josephrussell123@gmail.com)")
-        .about("Calculates Alcohol by Weight (ABW) from Alcohol By Volue (ABV) and vice versa")
-        .arg(
-            Arg::with_name("percent")
-                .short("p")
-                .long("percent")
-                .value_name("PERCENT")
-                .help("'From' alcohol percentage")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("volume")
-                .short("v")
-                .long("volume")
-                .value_name("VOLUME")
-                .help("Total beer volume")
-                .required(false)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("density")
-                .short("d")
-                .long("density")
-                .value_name("DENSITY")
-                .help("Total density of beer in g/cm³")
-                .required(false)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("reverse")
-                .short("r")
-                .long("reverse")
-                .value_name("REVERSE")
-                .help("Calculates ABW to ABV")
-                .required(false)
-                .takes_value(false),
-        )
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "abv_abw",
+    author = "Joseph Russell (josephrussell123@gmail.com)"
+)]
+/// Calculates Alcohol by Weight (ABW) from Alcohol By Volue (ABV) and vice versa
+pub struct AbvAbwOptions {
+    #[structopt(short, long)]
+    /// 'From' alcohol percentage
+    percent: f64,
+
+    #[structopt(short, long, parse(try_from_str = VolumeParser::parse))]
+    /// Total beer volume
+    volume: Option<Volume>,
+
+    #[structopt(short, long, required_unless("fg"))]
+    /// Total density of beer in g/cm³
+    density: Option<f64>,
+
+    #[structopt(short, long)]
+    /// Calculates ABW to ABV
+    reverse: Option<bool>,
 }
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("abv_abw") {
-        if matches.is_present("percent") {
-            let percent = value_t!(matches, "percent", f64).unwrap_or_else(|e| e.exit());
-            let end_percentage: f64;
+pub fn calculate_and_print(abv_abw: AbvAbwOptions) {
+    let end_percentage: f64;
+    // main ABV <-> ABW conversion
+    if Some(true) == abv_abw.reverse {
+        end_percentage = match abv_abw.density {
+            Some(density) => calculate_abw_abv_density(abv_abw.percent, density),
+            None => calculate_abw_abv(abv_abw.percent),
+        };
 
-            // main ABV <-> ABW conversion
-            if matches.is_present("reverse") {
-                if matches.is_present("density") {
-                    let density = value_t!(matches, "density", f64).unwrap_or_else(|e| e.exit());
-                    end_percentage = calculate_abw_abv_density(percent, density);
-                } else {
-                    end_percentage = calculate_abw_abv(percent);
-                }
-                println!("ABV: {:.3}%", end_percentage);
-            } else {
-                if matches.is_present("density") {
-                    let density = value_t!(matches, "density", f64).unwrap_or_else(|e| e.exit());
-                    end_percentage = calculate_abv_abw_density(percent, density);
-                } else {
-                    end_percentage = calculate_abv_abw(percent);
-                }
-                println!("ABW: {:.3}%", end_percentage);
-            }
+        println!("ABV: {:.3}%", end_percentage);
+    } else {
+        end_percentage = match abv_abw.density {
+            Some(density) => calculate_abv_abw_density(abv_abw.percent, density),
+            None => calculate_abv_abw(abv_abw.percent),
+        };
+        println!("ABW: {:.3}%", end_percentage);
+    }
 
-            // Quantity of alcohol
-            if matches.is_present("volume") {
-                let volume = value_t!(matches, "volume", String).unwrap_or_else(|e| e.exit());
-                let volume_ml = VolumeBuilder::new(&volume).unwrap().as_millilitres();
-                if matches.is_present("reverse") {
-                    println!(
-                        "Alcohol: {:.3} ml",
-                        calculate_alc_vol(volume_ml, end_percentage)
-                    );
-                } else {
-                    println!("Alcohol: {:.3} g", calculate_alc_weight(volume_ml, percent));
-                }
-            }
+    // Quantity of alcohol
+    if let Some(volume) = abv_abw.volume {
+        if Some(true) == abv_abw.reverse {
+            println!(
+                "Alcohol: {:.3} ml",
+                calculate_alc_vol(volume.as_millilitres(), end_percentage)
+            );
         } else {
-            println!("The alcohol percentage has not been specified.");
-            println!("{}", matches.usage());
+            println!(
+                "Alcohol: {:.3} g",
+                calculate_alc_weight(volume.as_millilitres(), abv_abw.percent)
+            );
         }
     }
 }

--- a/rustybeer-cli/src/commands/beer_style.rs
+++ b/rustybeer-cli/src/commands/beer_style.rs
@@ -1,90 +1,62 @@
-use clap::{App, Arg, ArgMatches};
 pub use rustybeer_util::beer_styles::{BeerStyle, Criteria, BEER_STYLES};
+use structopt::StructOpt;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("beer_style")
-        .version("0.1")
-        .author("Heikki Hellgren (heiccih@gmail.com)")
-        .about("Finds matches of beer style based on parameters")
-        .arg(
-            Arg::with_name("og")
-                .short("o")
-                .long("og")
-                .value_name("OG")
-                .help("Original gravity")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("fg")
-                .short("f")
-                .long("fg")
-                .value_name("FG")
-                .help("Final gravity")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("abv")
-                .short("a")
-                .long("abv")
-                .value_name("ABV")
-                .help("Alcohol By Volume")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("ibu")
-                .short("i")
-                .long("ibu")
-                .value_name("IBU")
-                .help("International Bittering Units")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("color")
-                .short("c")
-                .long("color")
-                .value_name("COLOR")
-                .help("Standard Rererence Model Color")
-                .takes_value(true),
-        )
+#[derive(Debug, StructOpt)]
+#[structopt(name = "beer_style", author = "Heikki Hellgren (heiccih@gmail.com)")]
+/// Finds matches of beer style based on parameters
+pub struct BeerStyleOptions {
+    #[structopt(short, long)]
+    /// Original gravity
+    og: f32,
+
+    #[structopt(short, long)]
+    /// Final gravity
+    fg: f32,
+
+    #[structopt(short, long)]
+    /// Alcohol by volume
+    abv: f32,
+
+    #[structopt(short, long)]
+    /// International Bittering Units
+    ibu: u8,
+
+    #[structopt(short, long)]
+    /// Standard Reference Model Color
+    color: f32,
 }
 
-fn matches_to_criteria(matches: &ArgMatches) -> Criteria {
-    Criteria {
-        og: matches.value_of("og").map(|value| value.parse().unwrap()),
-        fg: matches.value_of("fg").map(|value| value.parse().unwrap()),
-        abv: matches.value_of("abv").map(|value| value.parse().unwrap()),
-        ibu: matches.value_of("ibu").map(|value| value.parse().unwrap()),
-        srm: matches.value_of("srm").map(|value| value.parse().unwrap()),
+pub fn calculate_and_print(beer_style_options: BeerStyleOptions) {
+    let criteria = Criteria {
+        og: Some(beer_style_options.og),
+        fg: Some(beer_style_options.fg),
+        abv: Some(beer_style_options.abv),
+        ibu: Some(beer_style_options.ibu),
+        srm: Some(beer_style_options.color),
+    };
+    let mut resp: Vec<&BeerStyle> = Vec::new();
+
+    for style in BEER_STYLES.iter() {
+        if criteria.matches(style) {
+            resp.push(style)
+        }
     }
-}
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("beer_style") {
-        let criteria = matches_to_criteria(matches);
-        let mut resp: Vec<&BeerStyle> = Vec::new();
+    if resp.is_empty() {
+        println!("Could not find any beer styles matching criteria");
+        return;
+    }
 
-        for style in BEER_STYLES.iter() {
-            if criteria.matches(style) {
-                resp.push(style)
-            }
-        }
-
-        if resp.is_empty() {
-            println!("Could not find any beer styles matching criteria");
-            return;
-        }
-
-        println!("Found the following beer styles with criteria:");
-        for x in &resp {
-            println!("---------------------");
-            println!("{}\n", x.name);
-            println!("{}\n", x.description);
-            println!("OG: {}-{}", x.original_gravity_min, x.original_gravity_max);
-            println!("FG: {}-{}", x.final_gravity_min, x.final_gravity_max);
-            println!("ABV: {}%-{}%", x.abv_min, x.abv_max);
-            println!("IBU: {}-{}", x.ibu_min, x.ibu_max);
-            println!("SRM: {}-{}", x.color_srm_min, x.color_srm_max);
-        }
+    println!("Found the following beer styles with criteria:");
+    for x in &resp {
         println!("---------------------");
+        println!("{}\n", x.name);
+        println!("{}\n", x.description);
+        println!("OG: {}-{}", x.original_gravity_min, x.original_gravity_max);
+        println!("FG: {}-{}", x.final_gravity_min, x.final_gravity_max);
+        println!("ABV: {}%-{}%", x.abv_min, x.abv_max);
+        println!("IBU: {}-{}", x.ibu_min, x.ibu_max);
+        println!("SRM: {}-{}", x.color_srm_min, x.color_srm_max);
     }
+    println!("---------------------");
 }

--- a/rustybeer-cli/src/commands/calories.rs
+++ b/rustybeer-cli/src/commands/calories.rs
@@ -1,132 +1,107 @@
-use clap::{value_t, App, Arg, ArgMatches};
 use rustybeer::calculators::calorie_counter::{
     calculate_alcohol_calories, calculate_carbs_calories, calculate_total_calories,
 };
 use rustybeer::calculators::num_bottles::bottles;
-use rustybeer_util::abv_calories::{Criteria, ABV_CALORIES};
-use rustybeer_util::conversions::{MassBuilder, VolumeBuilder};
+use rustybeer_util::{
+    abv_calories::{Criteria, ABV_CALORIES},
+    conversions::{MassParser, VolumeParser},
+    measurements::Volume,
+};
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("calories")
-            .version("0.1")
-            .author("Roger Yu (roger.yu27 [at] gmail.com)")
-            .about("Calculates calories by volume from original and final gravity or from alcohol by volume")
-            .arg(Arg::with_name("og")
-                 .short("o")
-                 .long("og")
-                 .value_name("OG")
-                 .help("Original gravity")
-                 .required(false)
-                 .takes_value(true))
-            .arg(Arg::with_name("fg")
-                 .short("f")
-                 .long("fg")
-                 .value_name("FG")
-                 .help("Final gravity")
-                 .required(false)
-                 .takes_value(true))
-            .arg(Arg::with_name("abv")
-                 .short("a")
-                 .long("abv")
-                 .value_name("ABV")
-                 .help("Alcohol by volume")
-                 .required_unless("fg")
-                 .takes_value(true))
-            .arg(Arg::with_name("volume")
-                 .short("v")
-                 .long("volume")
-                 .value_name("vol")
-                 .help("Volume as a string ('e.g 10mL, 4gal')")
-                 .required(false)
-                 .takes_value(true))
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "calories", author = "Roger Yu (roger.yu27 [at] gmail.com)")]
+/// Calculates calories by volume from original and final gravity or from alcohol by volume
+pub struct CaloriesOptions {
+    #[structopt(short, long)]
+    /// Original gravity
+    og: Option<f32>,
+
+    #[structopt(short, long, requires("og"), required_unless("abv"))]
+    /// Final gravity
+    fg: Option<f32>,
+
+    #[structopt(short, long, required_unless("fg"))]
+    /// Alcohol by volume
+    abv: Option<f32>,
+
+    #[structopt(short, long, parse(try_from_str = VolumeParser::parse))]
+    /// Volume
+    volume: Option<Volume>,
 }
 
-fn matches_to_criteria<'a>(matches: &ArgMatches<'a>) -> Criteria {
-    Criteria {
-        abv: matches.value_of("abv").map(|value| value.parse().unwrap()),
-    }
-}
-
-pub fn do_matches<'a>(matches: &ArgMatches<'a>) {
-    if let Some(matches) = matches.subcommand_matches("calories") {
-        let conversion = MassBuilder::new("12oz").unwrap().as_grams() as f32;
-        if matches.is_present("fg") && matches.is_present("og") && !matches.is_present("abv") {
-            let fg = value_t!(matches, "fg", f32).unwrap_or_else(|e| e.exit());
-            let og = value_t!(matches, "og", f32).unwrap_or_else(|e| e.exit());
-            if matches.is_present("volume") {
-                let vol = value_t!(matches, "volume", String).unwrap_or_else(|e| e.exit());
-                let volume = VolumeBuilder::new(&vol).unwrap().as_milliliters();
-                let ac = calculate_alcohol_calories(og, fg) / conversion * volume as f32;
-                let cc = calculate_carbs_calories(og, fg) / conversion * volume as f32;
-                let tc = calculate_total_calories(og, fg) / conversion * volume as f32;
-                println!("Estimated calories for: {} ml", volume);
-                println!("==============================");
-                println!("| {:<8} | {:<6} | {:<6} |", "", "kcal:", "kJ:");
-                println!("| {:<8} | {:>6.0} | {:>6.0} |", "Alcohol:", ac, ac * 4.184);
-                println!("| {:<8} | {:>6.0} | {:>6.0} |", "Carbs:", cc, cc * 4.184);
-                println!("| {:<8} | {:>6.0} | {:>6.0} |", "Total:", tc, tc * 4.184);
-                println!("==============================");
-            } else {
-                println!("Total estimated calories for:");
-                println!("==========================================================");
-                let bottles = calculate_calories_per_bottle(conversion, og, fg);
-                for bottle in bottles {
-                    let output = format!(
-                        "| Type: {: <20} | kcal: {: >6} | kJ: {: >6.0} |",
-                        bottle.0,
-                        bottle.1,
-                        bottle.1 * 4.184
-                    );
-                    println!("{}", output);
-                }
-                println!("==========================================================");
-            }
-        } else if matches.is_present("abv")
-            && !matches.is_present("fg")
-            && !matches.is_present("og")
-        {
-            if matches.is_present("volume") {
-                let vol = value_t!(matches, "volume", String).unwrap_or_else(|e| e.exit());
-                let volume = VolumeBuilder::new(&vol).unwrap().as_milliliters() as f32;
-                let criteria = matches_to_criteria(matches);
-                for abv in ABV_CALORIES.iter() {
-                    if criteria.matches(abv) {
-                        let lc = abv.calories_low / conversion * volume;
-                        let hc = abv.calories_high / conversion * volume;
-                        println!("Total estimated calories range for: {} ml", volume);
-                        println!("=========================");
-                        println!("| {:>6.0} to {:<6.0} kcal |", lc, hc);
-                        println!("| {:>6.0} to {:<6.0} kJ   |", lc * 4.184, hc * 4.184);
-                        println!("=========================");
-                        return;
-                    }
-                }
-            } else {
-                let criteria = matches_to_criteria(matches);
-                for abv in ABV_CALORIES.iter() {
-                    if criteria.matches(abv) {
-                        println!("Total estimated calories range for:");
-                        println!("============================================================================");
-                        let bottles = get_list_of_volumes_from_bottles();
-                        for bottle in bottles {
-                            let lc = abv.calories_low / conversion * bottle.1;
-                            let hc = abv.calories_high / conversion * bottle.1;
-                            let output = format!(
-                                "| Type: {: <20} | kcal: {:>5.0} to {:<5.0} | kJ: {:>6.0} to {:<6.0} |",
-                                bottle.0, lc, hc, lc * 4.184, hc * 4.184
-                            );
-                            println!("{}", output);
-                        }
-                        println!("============================================================================");
-                        return;
-                    }
-                }
-            };
-            println!("Could not find any ABV to calories matching criteria (range: 0 to 22)");
+pub fn calculate_and_print(calories: CaloriesOptions) {
+    let conversion = MassParser::parse("12oz").unwrap().as_grams() as f32;
+    if calories.og.is_some() && calories.fg.is_some() {
+        let fg = calories.fg.unwrap();
+        let og = calories.og.unwrap();
+        if let Some(volume) = calories.volume {
+            let volume = volume.as_milliliters();
+            let ac = calculate_alcohol_calories(og, fg) / conversion * volume as f32;
+            let cc = calculate_carbs_calories(og, fg) / conversion * volume as f32;
+            let tc = calculate_total_calories(og, fg) / conversion * volume as f32;
+            println!("Estimated calories for: {} ml", volume);
+            println!("==============================");
+            println!("| {:<8} | {:<6} | {:<6} |", "", "kcal:", "kJ:");
+            println!("| {:<8} | {:>6.0} | {:>6.0} |", "Alcohol:", ac, ac * 4.184);
+            println!("| {:<8} | {:>6.0} | {:>6.0} |", "Carbs:", cc, cc * 4.184);
+            println!("| {:<8} | {:>6.0} | {:>6.0} |", "Total:", tc, tc * 4.184);
+            println!("==============================");
         } else {
-            println!("Either specify original gravity and final gravity or just abv!");
-            println!("{}", matches.usage());
+            println!("Total estimated calories for:");
+            println!("==========================================================");
+            let bottles = calculate_calories_per_bottle(conversion, og, fg);
+            for bottle in bottles {
+                let output = format!(
+                    "| Type: {: <20} | kcal: {: >6} | kJ: {: >6.0} |",
+                    bottle.0,
+                    bottle.1,
+                    bottle.1 * 4.184
+                );
+                println!("{}", output);
+            }
+            println!("==========================================================");
         }
+    } else if calories.abv.is_some() {
+        if let Some(volume) = calories.volume {
+            let volume = volume.as_milliliters() as f32;
+            let criteria = Criteria { abv: calories.abv };
+            for abv in ABV_CALORIES.iter() {
+                if criteria.matches(abv) {
+                    let lc = abv.calories_low / conversion * volume;
+                    let hc = abv.calories_high / conversion * volume;
+                    println!("Total estimated calories range for: {} ml", volume);
+                    println!("=========================");
+                    println!("| {:>6.0} to {:<6.0} kcal |", lc, hc);
+                    println!("| {:>6.0} to {:<6.0} kJ   |", lc * 4.184, hc * 4.184);
+                    println!("=========================");
+                    return;
+                }
+            }
+        } else {
+            let criteria = Criteria { abv: calories.abv };
+            for abv in ABV_CALORIES.iter() {
+                if criteria.matches(abv) {
+                    println!("Total estimated calories range for:");
+                    println!("============================================================================");
+                    let bottles = get_list_of_volumes_from_bottles();
+                    for bottle in bottles {
+                        let lc = abv.calories_low / conversion * bottle.1;
+                        let hc = abv.calories_high / conversion * bottle.1;
+                        let output =
+                            format!(
+                            "| Type: {: <20} | kcal: {:>5.0} to {:<5.0} | kJ: {:>6.0} to {:<6.0} |",
+                            bottle.0, lc, hc, lc * 4.184, hc * 4.184
+                        );
+                        println!("{}", output);
+                    }
+                    println!("============================================================================");
+                    return;
+                }
+            }
+        }
+        println!("Could not find any ABV to calories matching criteria (range: 0 to 22)");
     }
 }
 

--- a/rustybeer-cli/src/commands/diluting.rs
+++ b/rustybeer-cli/src/commands/diluting.rs
@@ -1,45 +1,33 @@
-use clap::{value_t, App, Arg, ArgMatches};
 use rustybeer::calculators::diluting::calculate_new_gravity;
+use structopt::StructOpt;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("diluting")
-        .version("0.1")
-        .author("Joseph Russell (josephrussell123@gmail.com)")
-        .about("Calculates the SG after dilution")
-        .arg(
-            Arg::with_name("sg")
-                .short("g")
-                .long("sg")
-                .value_name("SG")
-                .help("Current specific gravity")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("cv")
-                .short("c")
-                .long("cv")
-                .value_name("CV")
-                .help("Current volume")
-                .required(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("tv")
-                .short("t")
-                .long("tv")
-                .value_name("TV")
-                .help("Target volume")
-                .required(true)
-                .takes_value(true),
-        )
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "diluting",
+    author = "Joseph Russell (josephrussell123@gmail.com)"
+)]
+/// Calculates the SG after dilution
+pub struct DilutingOptions {
+    #[structopt(short, long)]
+    /// Current specific gravity
+    sg: f32,
+
+    #[structopt(short, long)]
+    /// Current Volume
+    cv: f32,
+
+    #[structopt(short, long)]
+    /// Target Volume
+    tv: f32,
 }
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("diluting") {
-        let sg = value_t!(matches, "sg", f32).unwrap_or_else(|e| e.exit());
-        let cv = value_t!(matches, "cv", f32).unwrap_or_else(|e| e.exit());
-        let tv = value_t!(matches, "tv", f32).unwrap_or_else(|e| e.exit());
-        println!("New SG: {:.3}", calculate_new_gravity(sg, cv, tv));
-    }
+pub fn calculate_and_print(diluting_options: DilutingOptions) {
+    println!(
+        "New SG: {:.3}",
+        calculate_new_gravity(
+            diluting_options.sg,
+            diluting_options.cv,
+            diluting_options.tv
+        )
+    );
 }

--- a/rustybeer-cli/src/commands/mod.rs
+++ b/rustybeer-cli/src/commands/mod.rs
@@ -1,8 +1,8 @@
 pub mod abv;
-pub mod alcohol_volume_weight;
+//pub mod alcohol_volume_weight;
 pub mod beer_style;
 pub mod boil_off;
-pub mod calories;
+//pub mod calories;
 pub mod diluting;
 pub mod num_bottles;
 pub mod priming;

--- a/rustybeer-cli/src/commands/mod.rs
+++ b/rustybeer-cli/src/commands/mod.rs
@@ -1,8 +1,8 @@
 pub mod abv;
-//pub mod alcohol_volume_weight;
+pub mod alcohol_volume_weight;
 pub mod beer_style;
 pub mod boil_off;
-//pub mod calories;
+pub mod calories;
 pub mod diluting;
 pub mod num_bottles;
 pub mod priming;

--- a/rustybeer-cli/src/commands/num_bottles.rs
+++ b/rustybeer-cli/src/commands/num_bottles.rs
@@ -1,6 +1,6 @@
-use measurements::Volume;
 use rustybeer::calculators::num_bottles::calculate_num_bottles;
 use rustybeer_util::conversions::VolumeBuilder;
+use rustybeer_util::measurements::Volume;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rustybeer-cli/src/commands/num_bottles.rs
+++ b/rustybeer-cli/src/commands/num_bottles.rs
@@ -1,38 +1,31 @@
-use clap::{value_t, App, Arg, ArgMatches};
+use measurements::Volume;
 use rustybeer::calculators::num_bottles::calculate_num_bottles;
-use rustybeer_util::conversions::VolumeBuilder; // Converts string input to unit measurements
+use rustybeer_util::conversions::VolumeBuilder;
+use structopt::StructOpt;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new(
-            "num_bottles")
-                .version("0.1")
-                .author("Ilakkiyan Jeyakumar (ilakkiyan.jeyakumar@gmail.com)")
-                .about("Calculates the number of different standard-size bottles needed to contain a given volume")
-                .arg(
-                    Arg::with_name("volume")
-                        .short("v")
-                        .long("volume")
-                        .value_name("vol")
-                        .help("Volume as a string ('e.g 10mL, 4gal')")
-                        .required(true)
-                        .takes_value(true),
-        )
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "num_bottles",
+    author = "Ilakkiyan Jeyakumar (ilakkiyan.jeyakumar@gmail.com)"
+)]
+/// Calculates the number of different standard-size bottles needed to contain a given volume
+pub struct NumBottlesOptions {
+    #[structopt(short, long, parse(try_from_str = VolumeBuilder::new))]
+    /// Volume as a string ('e.g 10mL, 4gal')
+    volume: Volume,
 }
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(ref matches) = matches.subcommand_matches("num_bottles") {
-        let vol = value_t!(matches, "volume", String).unwrap_or_else(|e| e.exit());
-        let volume = VolumeBuilder::new(&vol).unwrap().as_milliliters();
-        println!("Volume to contain: {}", vol);
-        println!("=========================================================");
-        let bottles = calculate_num_bottles(volume);
-        for bottle in bottles {
-            let output = format!(
-                "| Type: {0: <20} | Quantity required: {1: <5} |",
-                bottle.0, bottle.1
-            );
-            println!("{}", output);
-        }
-        println!("=========================================================");
+pub fn calculate_and_print(num_bottles_options: NumBottlesOptions) {
+    let volume = num_bottles_options.volume.as_milliliters();
+    println!("Volume to contain: {} ml", volume);
+    println!("=========================================================");
+    let bottles = calculate_num_bottles(volume);
+    for bottle in bottles {
+        let output = format!(
+            "| Type: {0: <20} | Quantity required: {1: <5} |",
+            bottle.0, bottle.1
+        );
+        println!("{}", output);
     }
+    println!("=========================================================");
 }

--- a/rustybeer-cli/src/commands/num_bottles.rs
+++ b/rustybeer-cli/src/commands/num_bottles.rs
@@ -1,6 +1,5 @@
 use rustybeer::calculators::num_bottles::calculate_num_bottles;
-use rustybeer_util::conversions::VolumeBuilder;
-use rustybeer_util::measurements::Volume;
+use rustybeer_util::{conversions::VolumeParser, measurements::Volume};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -10,7 +9,7 @@ use structopt::StructOpt;
 )]
 /// Calculates the number of different standard-size bottles needed to contain a given volume
 pub struct NumBottlesOptions {
-    #[structopt(short, long, parse(try_from_str = VolumeBuilder::new))]
+    #[structopt(short, long, parse(try_from_str = VolumeParser::parse))]
     /// Volume as a string ('e.g 10mL, 4gal')
     volume: Volume,
 }

--- a/rustybeer-cli/src/commands/priming.rs
+++ b/rustybeer-cli/src/commands/priming.rs
@@ -1,17 +1,19 @@
 use rustybeer::calculators::priming::{calculate_co2, calculate_sugars};
-use rustybeer_util::conversions::{TemperatureBuilder, VolumeBuilder};
-use rustybeer_util::measurements::{Temperature, Volume};
+use rustybeer_util::{
+    conversions::{TemperatureParser, VolumeParser},
+    measurements::{Temperature, Volume},
+};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "priming")]
 /// Beer Priming Calculator
 pub struct PrimingOptions {
-    #[structopt(short, long, parse(try_from_str = TemperatureBuilder::new))]
+    #[structopt(short, long, parse(try_from_str = TemperatureParser::parse))]
     /// Temperature of beer with unit (C, F, K). Defaults to Celsius.
     temp: Temperature,
 
-    #[structopt(short, long = "amount", parse(try_from_str = VolumeBuilder::new))]
+    #[structopt(short, long = "amount", parse(try_from_str = VolumeParser::parse))]
     /// Amount being packaged with unit (l, ml, gal, etc.). Defaults to liters.
     amount: Volume,
 

--- a/rustybeer-cli/src/commands/priming.rs
+++ b/rustybeer-cli/src/commands/priming.rs
@@ -1,6 +1,6 @@
-use measurements::{Temperature, Volume};
 use rustybeer::calculators::priming::{calculate_co2, calculate_sugars};
 use rustybeer_util::conversions::{TemperatureBuilder, VolumeBuilder};
+use rustybeer_util::measurements::{Temperature, Volume};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/rustybeer-cli/src/commands/priming.rs
+++ b/rustybeer-cli/src/commands/priming.rs
@@ -1,52 +1,37 @@
-use clap::{value_t, App, Arg, ArgMatches};
+use measurements::{Temperature, Volume};
 use rustybeer::calculators::priming::{calculate_co2, calculate_sugars};
 use rustybeer_util::conversions::{TemperatureBuilder, VolumeBuilder};
+use structopt::StructOpt;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("priming")
-                .about("Beer Priming Calculator")   // The message displayed in "-h"
-                .arg(Arg::with_name("temp")         // Priming own arguments
-                        .long("temp")
-                        .short("t")
-                        .help("Temperature of beer with unit (C, F, K). Defaults to Celsius.")
-                        .default_value("20C")
-                        .required(true)
-                        .takes_value(true))
-                .arg(Arg::with_name("amount")
-                        .long("amount")
-                        .short("a")
-                        .help("Amount being packaged with unit (l, ml, gal, etc.). Defaults to liters.")
-                        .default_value("25l")
-                        .takes_value(true))
-                .arg(Arg::with_name("co2_volumes")
-                        .long("co2_volumes")
-                        .short("c")
-                        .help("Volumes of wanted CO2, depends on beer style (e.g. British Style Ales 1.5 to 2.0)")
-                        .default_value("2.0")
-                        .takes_value(true))
+#[derive(Debug, StructOpt)]
+#[structopt(name = "priming")]
+/// Beer Priming Calculator
+pub struct PrimingOptions {
+    #[structopt(short, long, parse(try_from_str = TemperatureBuilder::new))]
+    /// Temperature of beer with unit (C, F, K). Defaults to Celsius.
+    temp: Temperature,
+
+    #[structopt(short, long = "amount", parse(try_from_str = VolumeBuilder::new))]
+    /// Amount being packaged with unit (l, ml, gal, etc.). Defaults to liters.
+    amount: Volume,
+
+    #[structopt(short, long = "co2_volumes", default_value = "2.0")]
+    /// Volumes of wanted CO2, depends on beer style (e.g. British Style Ales 1.5 to 2.0)
+    co2_volumes: f64,
 }
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(sub_matches) = matches.subcommand_matches("priming") {
-        let temperature = value_t!(sub_matches, "temp", String).unwrap_or_else(|e| e.exit());
-        let amount_str = value_t!(sub_matches, "amount", String).unwrap_or_else(|e| e.exit());
-        let co2_volumes = value_t!(sub_matches, "co2_volumes", f64).unwrap_or_else(|e| e.exit());
+pub fn calculate_and_print(priming: PrimingOptions) {
+    let fahrenheit = priming.temp.as_fahrenheit();
+    let amount = priming.amount.as_litres();
+    let co2_beer = calculate_co2(fahrenheit);
+    let sugars = calculate_sugars(fahrenheit, amount, priming.co2_volumes);
 
-        let fahrenheit = TemperatureBuilder::new(&temperature)
-            .unwrap()
-            .as_fahrenheit();
-        let amount = VolumeBuilder::new(&amount_str).unwrap().as_litres();
-        let co2_beer = calculate_co2(fahrenheit);
-        let sugars = calculate_sugars(fahrenheit, amount, co2_volumes);
-
-        println!("Amount: {}", amount_str);
-        println!("Volumes of CO2: {}", co2_volumes);
-        println!("Temperature: {}", temperature);
-        println!("CO2 in Beer: {:.2} volumes", co2_beer);
-        println!("Priming Sugar Options:");
-
-        for sugar in sugars.iter() {
-            println!("{:>23}: {:.2} g", sugar.name, sugar.ratio);
-        }
+    println!("Amount: {}l", amount);
+    println!("Volumes of CO2: {}", priming.co2_volumes);
+    println!("Temperature: {}C", fahrenheit);
+    println!("CO2 in Beer: {:.2} volumes", co2_beer);
+    println!("Priming Sugar Options:");
+    for sugar in sugars.iter() {
+        println!("{:>23}: {:.2} g", sugar.name, sugar.ratio);
     }
 }

--- a/rustybeer-cli/src/commands/sg_correction.rs
+++ b/rustybeer-cli/src/commands/sg_correction.rs
@@ -1,6 +1,5 @@
 use rustybeer::calculators::sg_correction::correct_sg;
-use rustybeer_util::conversions::TemperatureBuilder;
-use rustybeer_util::measurements::Temperature;
+use rustybeer_util::{conversions::TemperatureParser, measurements::Temperature};
 
 use structopt::StructOpt;
 
@@ -15,11 +14,11 @@ pub struct SgCorrectionOptions {
     /// Specific gravity reading
     sg: f64,
 
-    #[structopt(short, long, parse(try_from_str = TemperatureBuilder::new))]
+    #[structopt(short, long, parse(try_from_str = TemperatureParser::parse))]
     /// Calibration temperature with unit (C, F, K, etc.). Defaults to Celsius.
     ct: Temperature,
 
-    #[structopt(short, long, parse(try_from_str = TemperatureBuilder::new))]
+    #[structopt(short, long, parse(try_from_str = TemperatureParser::parse))]
     /// Measurement temperature with unit (C, F, K, etc.). Defaults to Celsius.
     mt: Temperature,
 }

--- a/rustybeer-cli/src/commands/sg_correction.rs
+++ b/rustybeer-cli/src/commands/sg_correction.rs
@@ -1,6 +1,6 @@
-use measurements::Temperature;
 use rustybeer::calculators::sg_correction::correct_sg;
 use rustybeer_util::conversions::TemperatureBuilder;
+use rustybeer_util::measurements::Temperature;
 
 use structopt::StructOpt;
 

--- a/rustybeer-cli/src/commands/sg_correction.rs
+++ b/rustybeer-cli/src/commands/sg_correction.rs
@@ -1,48 +1,37 @@
-use clap::{value_t, App, Arg, ArgMatches};
+use measurements::Temperature;
 use rustybeer::calculators::sg_correction::correct_sg;
 use rustybeer_util::conversions::TemperatureBuilder;
 
-pub fn add_subcommand<'a, 'b>() -> App<'a, 'b> {
-    let ret = App::new("sg_correction")
-            .version("0.1")
-            .author("Joseph Russell (josephrussell123@gmail.com)")
-            .about("Corrects SG reading according to the difference between the measurement temperature and the calibration temperature")
-            .arg(Arg::with_name("sg")
-                 .short("s")
-                 .long("sg")
-                 .value_name("GRAVITY")
-                 .help("Specific gravity reading")
-                 .required(true)
-                 .takes_value(true))
-            .arg(Arg::with_name("ct")
-                 .short("c")
-                 .long("ct")
-                 .value_name("CALIBRATION TEMPERATURE")
-                 .help("Calibration temperature with unit (C, F, K, etc.). Defaults to Celsius.")
-                 .required(true)
-                 .takes_value(true))
-            .arg(Arg::with_name("mt")
-                 .short("m")
-                 .long("mt")
-                 .value_name("MEASUREMENT TEMPERATURE")
-                 .help("Measurement temperature with unit (C, F, K, etc.). Defaults to Celsius.")
-                 .required(true)
-                 .takes_value(true));
+use structopt::StructOpt;
 
-    ret
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "sg_correction",
+    author("Joseph Russell (josephrussell123@gmail.com)")
+)]
+/// Corrects SG reading according to the difference between the measurement temperature and the calibration temperature
+pub struct SgCorrectionOptions {
+    #[structopt(short, long)]
+    /// Specific gravity reading
+    sg: f64,
+
+    #[structopt(short, long, parse(try_from_str = TemperatureBuilder::new))]
+    /// Calibration temperature with unit (C, F, K, etc.). Defaults to Celsius.
+    ct: Temperature,
+
+    #[structopt(short, long, parse(try_from_str = TemperatureBuilder::new))]
+    /// Measurement temperature with unit (C, F, K, etc.). Defaults to Celsius.
+    mt: Temperature,
 }
 
-pub fn do_matches(matches: &ArgMatches) {
-    if let Some(matches) = matches.subcommand_matches("sg_correction") {
-        let sg = value_t!(matches, "sg", f64).unwrap_or_else(|e| e.exit());
-        let ct_str = value_t!(matches, "ct", String).unwrap_or_else(|e| e.exit());
-        let ct = TemperatureBuilder::new(&ct_str).unwrap().as_fahrenheit();
-        let mt_str = value_t!(matches, "mt", String).unwrap_or_else(|e| e.exit());
-        let mt = TemperatureBuilder::new(&mt_str).unwrap().as_fahrenheit();
-
-        println!("Measured gravity: {}", sg);
-        println!("Calibration temperature: {}", ct_str);
-        println!("Measurement temperature: {}", mt_str);
-        println!("Corrected gravity: {:.3}", correct_sg(sg, ct, mt));
-    }
+pub fn calculate_and_print(sg_correction_options: SgCorrectionOptions) {
+    let ct = sg_correction_options.ct.as_fahrenheit();
+    let mt = sg_correction_options.mt.as_fahrenheit();
+    println!("Measured gravity: {}", sg_correction_options.sg);
+    println!("Calibration temperature: {} F", ct);
+    println!("Measurement temperature: {} F", mt);
+    println!(
+        "Corrected gravity: {:.3}",
+        correct_sg(sg_correction_options.sg, ct, mt)
+    );
 }

--- a/rustybeer-cli/src/main.rs
+++ b/rustybeer-cli/src/main.rs
@@ -7,8 +7,10 @@ mod commands;
 /// RustyBeer Calculators CLI
 pub enum RustyBeer {
     Abv(commands::abv::AbvOptions),
+    AbvAbw(commands::alcohol_volume_weight::AbvAbwOptions),
     BeerStyle(commands::beer_style::BeerStyleOptions),
     BoilOff(commands::boil_off::BoilOffOptions),
+    Calories(commands::calories::CaloriesOptions),
     Diluting(commands::diluting::DilutingOptions),
     NumBottles(commands::num_bottles::NumBottlesOptions),
     Priming(commands::priming::PrimingOptions),
@@ -19,8 +21,10 @@ fn main() -> Result<()> {
     let opt = RustyBeer::from_args_safe().with_context(|| "wrong arguments")?;
     match opt {
         RustyBeer::Abv(opts) => commands::abv::calculate_and_print(opts),
+        RustyBeer::AbvAbw(opts) => commands::alcohol_volume_weight::calculate_and_print(opts),
         RustyBeer::BeerStyle(opts) => commands::beer_style::calculate_and_print(opts),
         RustyBeer::BoilOff(opts) => commands::boil_off::calculate_and_print(opts),
+        RustyBeer::Calories(opts) => commands::calories::calculate_and_print(opts),
         RustyBeer::Diluting(opts) => commands::diluting::calculate_and_print(opts),
         RustyBeer::NumBottles(opts) => commands::num_bottles::calculate_and_print(opts),
         RustyBeer::Priming(opts) => commands::priming::calculate_and_print(opts),

--- a/rustybeer-cli/src/main.rs
+++ b/rustybeer-cli/src/main.rs
@@ -1,53 +1,28 @@
-use clap::{App, AppSettings};
-
+use structopt::StructOpt;
 mod commands;
 
-fn main() {
-    let app = App::new("RustyBeer")
-        .version("0.1")
-        .subcommand(commands::abv::add_subcommand())
-        .subcommand(commands::alcohol_volume_weight::add_subcommand())
-        .subcommand(commands::beer_style::add_subcommand())
-        .subcommand(commands::boil_off::add_subcommand())
-        .subcommand(commands::calories::add_subcommand())
-        .subcommand(commands::diluting::add_subcommand())
-        .subcommand(commands::priming::add_subcommand())
-        .subcommand(commands::num_bottles::add_subcommand())
-        .subcommand(commands::sg_correction::add_subcommand())
-        .setting(AppSettings::ArgRequiredElseHelp)
-        .get_matches();
+#[derive(Debug, StructOpt)]
+#[structopt(name = "RustyBeer", version = "0.1")]
+/// RustyBeer Calculators CLI
+pub enum RustyBeer {
+    Abv(commands::abv::AbvOptions),
+    BeerStyle(commands::beer_style::BeerStyleOptions),
+    BoilOff(commands::boil_off::BoilOffOptions),
+    Diluting(commands::diluting::DilutingOptions),
+    NumBottles(commands::num_bottles::NumBottlesOptions),
+    Priming(commands::priming::PrimingOptions),
+    SgCorrection(commands::sg_correction::SgCorrectionOptions),
+}
 
-    match app.subcommand_name() {
-        Some(s) => match s {
-            "abv" => {
-                commands::abv::do_matches(&app);
-            }
-            "abv_abw" => {
-                commands::alcohol_volume_weight::do_matches(&app);
-            }
-            "beer_style" => {
-                commands::beer_style::do_matches(&app);
-            }
-            "boil_off" => {
-                commands::boil_off::do_matches(&app);
-            }
-            "calories" => {
-                commands::calories::do_matches(&app);
-            }
-            "diluting" => {
-                commands::diluting::do_matches(&app);
-            }
-            "priming" => {
-                commands::priming::do_matches(&app);
-            }
-            "num_bottles" => {
-                commands::num_bottles::do_matches(&app);
-            }
-            "sg_correction" => {
-                commands::sg_correction::do_matches(&app);
-            }
-            _ => println!("Not recognised subcommand"),
-        },
-        None => println!("A subcommand must be provided"),
+fn main() {
+    let opt = RustyBeer::from_args();
+    match opt {
+        RustyBeer::Abv(opts) => commands::abv::calculate_and_print(opts),
+        RustyBeer::BeerStyle(opts) => commands::beer_style::calculate_and_print(opts),
+        RustyBeer::BoilOff(opts) => commands::boil_off::calculate_and_print(opts),
+        RustyBeer::Diluting(opts) => commands::diluting::calculate_and_print(opts),
+        RustyBeer::NumBottles(opts) => commands::num_bottles::calculate_and_print(opts),
+        RustyBeer::Priming(opts) => commands::priming::calculate_and_print(opts),
+        RustyBeer::SgCorrection(opts) => commands::sg_correction::calculate_and_print(opts),
     }
 }

--- a/rustybeer-cli/src/main.rs
+++ b/rustybeer-cli/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use structopt::StructOpt;
 mod commands;
 
@@ -14,8 +15,8 @@ pub enum RustyBeer {
     SgCorrection(commands::sg_correction::SgCorrectionOptions),
 }
 
-fn main() {
-    let opt = RustyBeer::from_args();
+fn main() -> Result<()> {
+    let opt = RustyBeer::from_args_safe().with_context(|| "wrong arguments")?;
     match opt {
         RustyBeer::Abv(opts) => commands::abv::calculate_and_print(opts),
         RustyBeer::BeerStyle(opts) => commands::beer_style::calculate_and_print(opts),
@@ -25,4 +26,6 @@ fn main() {
         RustyBeer::Priming(opts) => commands::priming::calculate_and_print(opts),
         RustyBeer::SgCorrection(opts) => commands::sg_correction::calculate_and_print(opts),
     }
+
+    Ok(())
 }

--- a/rustybeer-util/Cargo.toml
+++ b/rustybeer-util/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Heikki Hellgren <heiccih@gmail.com>", "mlatief", "Joseph Russell"]
 edition = "2018"
 
 [dependencies]
+approx = "0.4.0"
 measurements = "0.10.3"
 once_cell = "1.4.1"
 regex = "1.3.9"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.58"
-approx = "0.4.0"

--- a/rustybeer-util/src/conversions.rs
+++ b/rustybeer-util/src/conversions.rs
@@ -5,15 +5,15 @@ use std::num::ParseFloatError;
 ///
 /// To be removed if the dependency some time allows creating measurement units from
 /// strings.
-pub struct TemperatureBuilder;
+pub struct TemperatureParser;
 
-impl TemperatureBuilder {
+impl TemperatureParser {
     /// Creates measurements::Temperature from string
     ///
     /// Tries to figure out the temperature unit from the string. If the string value is plain
     /// number, it will be considered as Celsius. Also empty strings are considered as
     /// zero Celsius in Temperature.
-    pub fn new(val: &str) -> Result<measurements::Temperature, ParseFloatError> {
+    pub fn parse(val: &str) -> Result<measurements::Temperature, ParseFloatError> {
         if val.is_empty() {
             return Ok(measurements::Temperature::from_celsius(0.0));
         }
@@ -40,15 +40,15 @@ impl TemperatureBuilder {
 ///
 /// To be removed if the dependency some time allows creating measurement units from
 /// strings.
-pub struct VolumeBuilder;
+pub struct VolumeParser;
 
-impl VolumeBuilder {
+impl VolumeParser {
     /// Creates measurements::Volume from string
     ///
     /// Tries to figure out the volume unit from the string. If the string value is plain
     /// number, it will be considered as litres. Also empty strings are considered as
     /// zero litres in Volume.
-    pub fn new(val: &str) -> Result<measurements::Volume, ParseFloatError> {
+    pub fn parse(val: &str) -> Result<measurements::Volume, ParseFloatError> {
         if val.is_empty() {
             return Ok(measurements::Volume::from_litres(0.0));
         }
@@ -87,15 +87,15 @@ impl VolumeBuilder {
 ///
 /// To be removed if the dependency some time allows creating measurement units from
 /// strings.
-pub struct MassBuilder;
+pub struct MassParser;
 
-impl MassBuilder {
+impl MassParser {
     /// Creates measurements::Mass from string
     ///
     /// Tries to figure out the mass unit from the string. If the string value is plain
     /// number, it will be considered as grams. Also empty strings are considered as
     /// zero grams in Mass.
-    pub fn new(val: &str) -> Result<measurements::Mass, ParseFloatError> {
+    pub fn parse(val: &str) -> Result<measurements::Mass, ParseFloatError> {
         if val.is_empty() {
             return Ok(measurements::Mass::from_grams(0.0));
         }
@@ -125,88 +125,102 @@ impl MassBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{MassBuilder, TemperatureBuilder, VolumeBuilder};
+    use super::{MassParser, TemperatureParser, VolumeParser};
     use approx::assert_relative_eq;
 
     #[test]
     fn fahrenheit_from_string() {
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123F").unwrap().as_fahrenheit(),
+            TemperatureParser::parse("123F").unwrap().as_fahrenheit(),
         );
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 F").unwrap().as_fahrenheit(),
+            TemperatureParser::parse("123 F").unwrap().as_fahrenheit(),
         );
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 f").unwrap().as_fahrenheit(),
+            TemperatureParser::parse("123 f").unwrap().as_fahrenheit(),
         );
     }
 
     #[test]
     fn celsius_from_string() {
-        assert_relative_eq!(123.0, TemperatureBuilder::new("123C").unwrap().as_celsius(),);
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 C").unwrap().as_celsius(),
+            TemperatureParser::parse("123C").unwrap().as_celsius(),
         );
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 c").unwrap().as_celsius(),
+            TemperatureParser::parse("123 C").unwrap().as_celsius(),
+        );
+        assert_relative_eq!(
+            123.0,
+            TemperatureParser::parse("123 c").unwrap().as_celsius(),
         );
     }
 
     #[test]
     fn kelvin_from_string() {
-        assert_relative_eq!(123.0, TemperatureBuilder::new("123K").unwrap().as_kelvin(),);
-        assert_relative_eq!(123.0, TemperatureBuilder::new("123 K").unwrap().as_kelvin(),);
-        assert_relative_eq!(123.0, TemperatureBuilder::new("123 k").unwrap().as_kelvin(),);
+        assert_relative_eq!(123.0, TemperatureParser::parse("123K").unwrap().as_kelvin(),);
+        assert_relative_eq!(
+            123.0,
+            TemperatureParser::parse("123 K").unwrap().as_kelvin(),
+        );
+        assert_relative_eq!(
+            123.0,
+            TemperatureParser::parse("123 k").unwrap().as_kelvin(),
+        );
     }
 
     #[test]
     fn rankine_from_string() {
-        assert_relative_eq!(123.0, TemperatureBuilder::new("123R").unwrap().as_rankine(),);
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 R").unwrap().as_rankine(),
+            TemperatureParser::parse("123R").unwrap().as_rankine(),
         );
         assert_relative_eq!(
             123.0,
-            TemperatureBuilder::new("123 r").unwrap().as_rankine(),
+            TemperatureParser::parse("123 R").unwrap().as_rankine(),
+        );
+        assert_relative_eq!(
+            123.0,
+            TemperatureParser::parse("123 r").unwrap().as_rankine(),
         );
     }
 
     #[test]
     fn default_from_string() {
-        assert_relative_eq!(123.0, TemperatureBuilder::new("123").unwrap().as_celsius(),);
+        assert_relative_eq!(123.0, TemperatureParser::parse("123").unwrap().as_celsius(),);
 
-        assert_relative_eq!(123.0, VolumeBuilder::new("123").unwrap().as_litres(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123").unwrap().as_grams(),);
+        assert_relative_eq!(123.0, VolumeParser::parse("123").unwrap().as_litres(),);
+        assert_relative_eq!(123.0, MassParser::parse("123").unwrap().as_grams(),);
     }
 
     #[test]
     fn zero_from_string() {
-        assert_relative_eq!(0., TemperatureBuilder::new("").unwrap().as_celsius(),);
-        assert_relative_eq!(0., VolumeBuilder::new("").unwrap().as_litres());
-        assert_relative_eq!(0., MassBuilder::new("").unwrap().as_grams());
+        assert_relative_eq!(0., TemperatureParser::parse("").unwrap().as_celsius(),);
+        assert_relative_eq!(0., VolumeParser::parse("").unwrap().as_litres());
+        assert_relative_eq!(0., MassParser::parse("").unwrap().as_grams());
     }
 
     #[test]
     fn cubic_centimeters_from_string() {
         assert_relative_eq!(
             123.0,
-            VolumeBuilder::new("123cm3").unwrap().as_cubic_centimeters(),
-        );
-        assert_relative_eq!(
-            123.0,
-            VolumeBuilder::new("123 cm3")
+            VolumeParser::parse("123cm3")
                 .unwrap()
                 .as_cubic_centimeters(),
         );
         assert_relative_eq!(
             123.0,
-            VolumeBuilder::new("123 CM3")
+            VolumeParser::parse("123 cm3")
+                .unwrap()
+                .as_cubic_centimeters(),
+        );
+        assert_relative_eq!(
+            123.0,
+            VolumeParser::parse("123 CM3")
                 .unwrap()
                 .as_cubic_centimeters(),
         );
@@ -214,86 +228,92 @@ mod tests {
 
     #[test]
     fn milliliters_from_string() {
-        assert_relative_eq!(123.0, VolumeBuilder::new("123ml").unwrap().as_milliliters(),);
         assert_relative_eq!(
             123.0,
-            VolumeBuilder::new("123 ml").unwrap().as_milliliters(),
+            VolumeParser::parse("123ml").unwrap().as_milliliters(),
         );
         assert_relative_eq!(
             123.0,
-            VolumeBuilder::new("123 ml").unwrap().as_milliliters(),
+            VolumeParser::parse("123 ml").unwrap().as_milliliters(),
+        );
+        assert_relative_eq!(
+            123.0,
+            VolumeParser::parse("123 ml").unwrap().as_milliliters(),
         );
     }
 
     #[test]
     fn pints_from_string() {
-        assert_relative_eq!(123.0, VolumeBuilder::new("123p").unwrap().as_pints(),);
-        assert_relative_eq!(123.0, VolumeBuilder::new("123 p").unwrap().as_pints(),);
-        assert_relative_eq!(123.0, VolumeBuilder::new("123 P").unwrap().as_pints(),);
+        assert_relative_eq!(123.0, VolumeParser::parse("123p").unwrap().as_pints(),);
+        assert_relative_eq!(123.0, VolumeParser::parse("123 p").unwrap().as_pints(),);
+        assert_relative_eq!(123.0, VolumeParser::parse("123 P").unwrap().as_pints(),);
     }
 
     #[test]
     fn micrograms_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123ug").unwrap().as_micrograms(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 ug").unwrap().as_micrograms(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123μg").unwrap().as_micrograms(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 μg").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassParser::parse("123ug").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 ug").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassParser::parse("123μg").unwrap().as_micrograms(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 μg").unwrap().as_micrograms(),);
     }
 
     #[test]
     fn milligrams_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123mg").unwrap().as_milligrams(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 mg").unwrap().as_milligrams(),);
+        assert_relative_eq!(123.0, MassParser::parse("123mg").unwrap().as_milligrams(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 mg").unwrap().as_milligrams(),);
     }
 
     #[test]
     fn carats_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123ct").unwrap().as_carats(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 ct").unwrap().as_carats(),);
+        assert_relative_eq!(123.0, MassParser::parse("123ct").unwrap().as_carats(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 ct").unwrap().as_carats(),);
     }
 
     #[test]
     fn grams_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123g").unwrap().as_grams(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 g").unwrap().as_grams(),);
+        assert_relative_eq!(123.0, MassParser::parse("123g").unwrap().as_grams(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 g").unwrap().as_grams(),);
     }
 
     #[test]
     fn kilograms_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123kg").unwrap().as_kilograms(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 kg").unwrap().as_kilograms(),);
+        assert_relative_eq!(123.0, MassParser::parse("123kg").unwrap().as_kilograms(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 kg").unwrap().as_kilograms(),);
     }
 
     #[test]
     fn tonnes_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123T").unwrap().as_tonnes(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 T").unwrap().as_tonnes(),);
+        assert_relative_eq!(123.0, MassParser::parse("123T").unwrap().as_tonnes(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 T").unwrap().as_tonnes(),);
     }
 
     #[test]
     fn grains_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123gr").unwrap().as_grains(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 gr").unwrap().as_grains(),);
+        assert_relative_eq!(123.0, MassParser::parse("123gr").unwrap().as_grains(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 gr").unwrap().as_grains(),);
     }
 
     #[test]
     fn pennyweights_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123dwt").unwrap().as_pennyweights(),);
         assert_relative_eq!(
             123.0,
-            MassBuilder::new("123 dwt").unwrap().as_pennyweights(),
+            MassParser::parse("123dwt").unwrap().as_pennyweights(),
+        );
+        assert_relative_eq!(
+            123.0,
+            MassParser::parse("123 dwt").unwrap().as_pennyweights(),
         );
     }
 
     #[test]
     fn ounces_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123oz").unwrap().as_ounces(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 oz").unwrap().as_ounces(),);
+        assert_relative_eq!(123.0, MassParser::parse("123oz").unwrap().as_ounces(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 oz").unwrap().as_ounces(),);
     }
 
     #[test]
     fn pounds_from_string() {
-        assert_relative_eq!(123.0, MassBuilder::new("123lbs").unwrap().as_pounds(),);
-        assert_relative_eq!(123.0, MassBuilder::new("123 lbs").unwrap().as_pounds(),);
+        assert_relative_eq!(123.0, MassParser::parse("123lbs").unwrap().as_pounds(),);
+        assert_relative_eq!(123.0, MassParser::parse("123 lbs").unwrap().as_pounds(),);
     }
 }

--- a/rustybeer-util/src/conversions.rs
+++ b/rustybeer-util/src/conversions.rs
@@ -1,7 +1,8 @@
+use measurements::{Mass, Temperature, Volume};
 use regex::Regex;
 use std::num::ParseFloatError;
 
-/// Used to build new measurements::Temperature structs.
+/// Used to build new Temperature structs.
 ///
 /// To be removed if the dependency some time allows creating measurement units from
 /// strings.
@@ -13,9 +14,9 @@ impl TemperatureParser {
     /// Tries to figure out the temperature unit from the string. If the string value is plain
     /// number, it will be considered as Celsius. Also empty strings are considered as
     /// zero Celsius in Temperature.
-    pub fn parse(val: &str) -> Result<measurements::Temperature, ParseFloatError> {
+    pub fn parse(val: &str) -> Result<Temperature, ParseFloatError> {
         if val.is_empty() {
-            return Ok(measurements::Temperature::from_celsius(0.0));
+            return Ok(Temperature::from_celsius(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Z]{1})$").unwrap();
@@ -23,16 +24,16 @@ impl TemperatureParser {
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(
                 match caps.get(2).unwrap().as_str().to_uppercase().as_str() {
-                    "F" => measurements::Temperature::from_fahrenheit(float_val.parse::<f64>()?),
-                    "C" => measurements::Temperature::from_celsius(float_val.parse::<f64>()?),
-                    "K" => measurements::Temperature::from_kelvin(float_val.parse::<f64>()?),
-                    "R" => measurements::Temperature::from_rankine(float_val.parse::<f64>()?),
-                    _ => measurements::Temperature::from_celsius(val.parse::<f64>()?),
+                    "F" => Temperature::from_fahrenheit(float_val.parse::<f64>()?),
+                    "C" => Temperature::from_celsius(float_val.parse::<f64>()?),
+                    "K" => Temperature::from_kelvin(float_val.parse::<f64>()?),
+                    "R" => Temperature::from_rankine(float_val.parse::<f64>()?),
+                    _ => Temperature::from_celsius(val.parse::<f64>()?),
                 },
             );
         }
 
-        Ok(measurements::Temperature::from_celsius(val.parse::<f64>()?))
+        Ok(Temperature::from_celsius(val.parse::<f64>()?))
     }
 }
 
@@ -48,9 +49,9 @@ impl VolumeParser {
     /// Tries to figure out the volume unit from the string. If the string value is plain
     /// number, it will be considered as litres. Also empty strings are considered as
     /// zero litres in Volume.
-    pub fn parse(val: &str) -> Result<measurements::Volume, ParseFloatError> {
+    pub fn parse(val: &str) -> Result<Volume, ParseFloatError> {
         if val.is_empty() {
-            return Ok(measurements::Volume::from_litres(0.0));
+            return Ok(Volume::from_litres(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Z]{1,3}[0-9]{0,1})$").unwrap();
@@ -58,28 +59,26 @@ impl VolumeParser {
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(
                 match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "cm3" => {
-                        measurements::Volume::from_cubic_centimeters(float_val.parse::<f64>()?)
-                    }
-                    "ft3" => measurements::Volume::from_cubic_feet(float_val.parse::<f64>()?),
-                    "yd3" => measurements::Volume::from_cubic_yards(float_val.parse::<f64>()?),
-                    "in3" => measurements::Volume::from_cubic_inches(float_val.parse::<f64>()?),
-                    "gal" => measurements::Volume::from_gallons(float_val.parse::<f64>()?),
-                    "cup" => measurements::Volume::from_cups(float_val.parse::<f64>()?),
-                    "tsp" => measurements::Volume::from_teaspoons(float_val.parse::<f64>()?),
-                    "ml" => measurements::Volume::from_milliliters(float_val.parse::<f64>()?),
-                    "m3" => measurements::Volume::from_cubic_meters(float_val.parse::<f64>()?),
-                    "μl" => measurements::Volume::from_drops(float_val.parse::<f64>()?),
-                    "dr" => measurements::Volume::from_drams(float_val.parse::<f64>()?),
-                    "l" => measurements::Volume::from_litres(float_val.parse::<f64>()?),
-                    "p" => measurements::Volume::from_pints(float_val.parse::<f64>()?),
-                    "ʒ" => measurements::Volume::from_pints(float_val.parse::<f64>()?),
-                    _ => measurements::Volume::from_litres(val.parse::<f64>()?),
+                    "cm3" => Volume::from_cubic_centimeters(float_val.parse::<f64>()?),
+                    "ft3" => Volume::from_cubic_feet(float_val.parse::<f64>()?),
+                    "yd3" => Volume::from_cubic_yards(float_val.parse::<f64>()?),
+                    "in3" => Volume::from_cubic_inches(float_val.parse::<f64>()?),
+                    "gal" => Volume::from_gallons(float_val.parse::<f64>()?),
+                    "cup" => Volume::from_cups(float_val.parse::<f64>()?),
+                    "tsp" => Volume::from_teaspoons(float_val.parse::<f64>()?),
+                    "ml" => Volume::from_milliliters(float_val.parse::<f64>()?),
+                    "m3" => Volume::from_cubic_meters(float_val.parse::<f64>()?),
+                    "μl" => Volume::from_drops(float_val.parse::<f64>()?),
+                    "dr" => Volume::from_drams(float_val.parse::<f64>()?),
+                    "l" => Volume::from_litres(float_val.parse::<f64>()?),
+                    "p" => Volume::from_pints(float_val.parse::<f64>()?),
+                    "ʒ" => Volume::from_pints(float_val.parse::<f64>()?),
+                    _ => Volume::from_litres(val.parse::<f64>()?),
                 },
             );
         }
 
-        Ok(measurements::Volume::from_litres(val.parse::<f64>()?))
+        Ok(Volume::from_litres(val.parse::<f64>()?))
     }
 }
 
@@ -95,31 +94,31 @@ impl MassParser {
     /// Tries to figure out the mass unit from the string. If the string value is plain
     /// number, it will be considered as grams. Also empty strings are considered as
     /// zero grams in Mass.
-    pub fn parse(val: &str) -> Result<measurements::Mass, ParseFloatError> {
+    pub fn parse(val: &str) -> Result<Mass, ParseFloatError> {
         if val.is_empty() {
-            return Ok(measurements::Mass::from_grams(0.0));
+            return Ok(Mass::from_grams(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Zμ]{1,3})$").unwrap();
         if let Some(caps) = re.captures(val) {
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(match caps.get(2).unwrap().as_str() {
-                "ug" | "μg" => measurements::Mass::from_micrograms(float_val.parse::<f64>()?),
-                "mg" => measurements::Mass::from_milligrams(float_val.parse::<f64>()?),
-                "ct" => measurements::Mass::from_carats(float_val.parse::<f64>()?),
-                "g" => measurements::Mass::from_grams(float_val.parse::<f64>()?),
-                "kg" => measurements::Mass::from_kilograms(float_val.parse::<f64>()?),
-                "T" => measurements::Mass::from_metric_tons(float_val.parse::<f64>()?),
-                "gr" => measurements::Mass::from_grains(float_val.parse::<f64>()?),
-                "dwt" => measurements::Mass::from_pennyweights(float_val.parse::<f64>()?),
-                "oz" => measurements::Mass::from_ounces(float_val.parse::<f64>()?),
-                "st" => measurements::Mass::from_stones(float_val.parse::<f64>()?),
-                "lbs" => measurements::Mass::from_pounds(float_val.parse::<f64>()?),
-                _ => measurements::Mass::from_grams(float_val.parse::<f64>()?),
+                "ug" | "μg" => Mass::from_micrograms(float_val.parse::<f64>()?),
+                "mg" => Mass::from_milligrams(float_val.parse::<f64>()?),
+                "ct" => Mass::from_carats(float_val.parse::<f64>()?),
+                "g" => Mass::from_grams(float_val.parse::<f64>()?),
+                "kg" => Mass::from_kilograms(float_val.parse::<f64>()?),
+                "T" => Mass::from_metric_tons(float_val.parse::<f64>()?),
+                "gr" => Mass::from_grains(float_val.parse::<f64>()?),
+                "dwt" => Mass::from_pennyweights(float_val.parse::<f64>()?),
+                "oz" => Mass::from_ounces(float_val.parse::<f64>()?),
+                "st" => Mass::from_stones(float_val.parse::<f64>()?),
+                "lbs" => Mass::from_pounds(float_val.parse::<f64>()?),
+                _ => Mass::from_grams(float_val.parse::<f64>()?),
             });
         }
 
-        Ok(measurements::Mass::from_grams(val.parse::<f64>()?))
+        Ok(Mass::from_grams(val.parse::<f64>()?))
     }
 }
 

--- a/rustybeer-util/src/conversions.rs
+++ b/rustybeer-util/src/conversions.rs
@@ -1,8 +1,6 @@
 use regex::Regex;
 use std::num::ParseFloatError;
 
-use measurements::{Mass, Temperature, Volume};
-
 /// Used to build new measurements::Temperature structs.
 ///
 /// To be removed if the dependency some time allows creating measurement units from
@@ -17,7 +15,7 @@ impl TemperatureBuilder {
     /// zero Celsius in Temperature.
     pub fn new(val: &str) -> Result<measurements::Temperature, ParseFloatError> {
         if val.is_empty() {
-            return Ok(Temperature::from_celsius(0.0));
+            return Ok(measurements::Temperature::from_celsius(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Z]{1})$").unwrap();
@@ -25,16 +23,16 @@ impl TemperatureBuilder {
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(
                 match caps.get(2).unwrap().as_str().to_uppercase().as_str() {
-                    "F" => Temperature::from_fahrenheit(float_val.parse::<f64>()?),
-                    "C" => Temperature::from_celsius(float_val.parse::<f64>()?),
-                    "K" => Temperature::from_kelvin(float_val.parse::<f64>()?),
-                    "R" => Temperature::from_rankine(float_val.parse::<f64>()?),
-                    _ => Temperature::from_celsius(val.parse::<f64>()?),
+                    "F" => measurements::Temperature::from_fahrenheit(float_val.parse::<f64>()?),
+                    "C" => measurements::Temperature::from_celsius(float_val.parse::<f64>()?),
+                    "K" => measurements::Temperature::from_kelvin(float_val.parse::<f64>()?),
+                    "R" => measurements::Temperature::from_rankine(float_val.parse::<f64>()?),
+                    _ => measurements::Temperature::from_celsius(val.parse::<f64>()?),
                 },
             );
         }
 
-        Ok(Temperature::from_celsius(val.parse::<f64>()?))
+        Ok(measurements::Temperature::from_celsius(val.parse::<f64>()?))
     }
 }
 
@@ -52,7 +50,7 @@ impl VolumeBuilder {
     /// zero litres in Volume.
     pub fn new(val: &str) -> Result<measurements::Volume, ParseFloatError> {
         if val.is_empty() {
-            return Ok(Volume::from_litres(0.0));
+            return Ok(measurements::Volume::from_litres(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Z]{1,3}[0-9]{0,1})$").unwrap();
@@ -60,26 +58,28 @@ impl VolumeBuilder {
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(
                 match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "cm3" => Volume::from_cubic_centimeters(float_val.parse::<f64>()?),
-                    "ft3" => Volume::from_cubic_feet(float_val.parse::<f64>()?),
-                    "yd3" => Volume::from_cubic_yards(float_val.parse::<f64>()?),
-                    "in3" => Volume::from_cubic_inches(float_val.parse::<f64>()?),
-                    "gal" => Volume::from_gallons(float_val.parse::<f64>()?),
-                    "cup" => Volume::from_cups(float_val.parse::<f64>()?),
-                    "tsp" => Volume::from_teaspoons(float_val.parse::<f64>()?),
-                    "ml" => Volume::from_milliliters(float_val.parse::<f64>()?),
-                    "m3" => Volume::from_cubic_meters(float_val.parse::<f64>()?),
-                    "μl" => Volume::from_drops(float_val.parse::<f64>()?),
-                    "dr" => Volume::from_drams(float_val.parse::<f64>()?),
-                    "l" => Volume::from_litres(float_val.parse::<f64>()?),
-                    "p" => Volume::from_pints(float_val.parse::<f64>()?),
-                    "ʒ" => Volume::from_pints(float_val.parse::<f64>()?),
-                    _ => Volume::from_litres(val.parse::<f64>()?),
+                    "cm3" => {
+                        measurements::Volume::from_cubic_centimeters(float_val.parse::<f64>()?)
+                    }
+                    "ft3" => measurements::Volume::from_cubic_feet(float_val.parse::<f64>()?),
+                    "yd3" => measurements::Volume::from_cubic_yards(float_val.parse::<f64>()?),
+                    "in3" => measurements::Volume::from_cubic_inches(float_val.parse::<f64>()?),
+                    "gal" => measurements::Volume::from_gallons(float_val.parse::<f64>()?),
+                    "cup" => measurements::Volume::from_cups(float_val.parse::<f64>()?),
+                    "tsp" => measurements::Volume::from_teaspoons(float_val.parse::<f64>()?),
+                    "ml" => measurements::Volume::from_milliliters(float_val.parse::<f64>()?),
+                    "m3" => measurements::Volume::from_cubic_meters(float_val.parse::<f64>()?),
+                    "μl" => measurements::Volume::from_drops(float_val.parse::<f64>()?),
+                    "dr" => measurements::Volume::from_drams(float_val.parse::<f64>()?),
+                    "l" => measurements::Volume::from_litres(float_val.parse::<f64>()?),
+                    "p" => measurements::Volume::from_pints(float_val.parse::<f64>()?),
+                    "ʒ" => measurements::Volume::from_pints(float_val.parse::<f64>()?),
+                    _ => measurements::Volume::from_litres(val.parse::<f64>()?),
                 },
             );
         }
 
-        Ok(Volume::from_litres(val.parse::<f64>()?))
+        Ok(measurements::Volume::from_litres(val.parse::<f64>()?))
     }
 }
 
@@ -97,29 +97,29 @@ impl MassBuilder {
     /// zero grams in Mass.
     pub fn new(val: &str) -> Result<measurements::Mass, ParseFloatError> {
         if val.is_empty() {
-            return Ok(Mass::from_grams(0.0));
+            return Ok(measurements::Mass::from_grams(0.0));
         }
 
         let re = Regex::new(r"([0-9.]*)\s?([a-zA-Zμ]{1,3})$").unwrap();
         if let Some(caps) = re.captures(val) {
             let float_val = caps.get(1).unwrap().as_str();
             return Ok(match caps.get(2).unwrap().as_str() {
-                "ug" | "μg" => Mass::from_micrograms(float_val.parse::<f64>()?),
-                "mg" => Mass::from_milligrams(float_val.parse::<f64>()?),
-                "ct" => Mass::from_carats(float_val.parse::<f64>()?),
-                "g" => Mass::from_grams(float_val.parse::<f64>()?),
-                "kg" => Mass::from_kilograms(float_val.parse::<f64>()?),
-                "T" => Mass::from_metric_tons(float_val.parse::<f64>()?),
-                "gr" => Mass::from_grains(float_val.parse::<f64>()?),
-                "dwt" => Mass::from_pennyweights(float_val.parse::<f64>()?),
-                "oz" => Mass::from_ounces(float_val.parse::<f64>()?),
-                "st" => Mass::from_stones(float_val.parse::<f64>()?),
-                "lbs" => Mass::from_pounds(float_val.parse::<f64>()?),
-                _ => Mass::from_grams(float_val.parse::<f64>()?),
+                "ug" | "μg" => measurements::Mass::from_micrograms(float_val.parse::<f64>()?),
+                "mg" => measurements::Mass::from_milligrams(float_val.parse::<f64>()?),
+                "ct" => measurements::Mass::from_carats(float_val.parse::<f64>()?),
+                "g" => measurements::Mass::from_grams(float_val.parse::<f64>()?),
+                "kg" => measurements::Mass::from_kilograms(float_val.parse::<f64>()?),
+                "T" => measurements::Mass::from_metric_tons(float_val.parse::<f64>()?),
+                "gr" => measurements::Mass::from_grains(float_val.parse::<f64>()?),
+                "dwt" => measurements::Mass::from_pennyweights(float_val.parse::<f64>()?),
+                "oz" => measurements::Mass::from_ounces(float_val.parse::<f64>()?),
+                "st" => measurements::Mass::from_stones(float_val.parse::<f64>()?),
+                "lbs" => measurements::Mass::from_pounds(float_val.parse::<f64>()?),
+                _ => measurements::Mass::from_grams(float_val.parse::<f64>()?),
             });
         }
 
-        Ok(Mass::from_grams(val.parse::<f64>()?))
+        Ok(measurements::Mass::from_grams(val.parse::<f64>()?))
     }
 }
 

--- a/rustybeer-util/src/lib.rs
+++ b/rustybeer-util/src/lib.rs
@@ -8,4 +8,6 @@ pub mod beer_styles;
 pub mod conversions;
 pub mod hops;
 
+pub use measurements;
+
 mod macros;


### PR DESCRIPTION
- Use `structopt` for much nicer command line arguments parsing.
- Also for conversions utils use `mmmParser::parse` instead of `mmmBuilder::new`.
- And use `anyhow` for nicer error reporting.