### PR TITLE
Yeast viability

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Implemented              | Function                                             
 :white_check_mark:       | [Num Of Bottles](rustybeer-cli/src/commands/num_bottles.rs)        | Calculates the number of bottles required for a given volume       | `num_of_bottles --volume <volume>`
 :white_check_mark:       | [Priming](rustybeer-cli/src/commands/priming.rs)                   | Beer Priming Calculator                                            | `priming --temp <Beer temperature> --amount <Beer volume> --co2_volumes <co2_volumes>`
 :white_check_mark:       | [SG Correction](rustybeer-cli/src/commands/sg_correction.rs)       | Corrects SG reading for differences between measurement and calibration temperatures | `sg_correction --sg <Specific gravity reading> --ct <Calibration temperature> --mt <Measurement temperature>`
+:white_check_mark:       | [Yeast Viability](rustybeer-cli/src/commands/yeast_viability.rs)   | Estimates yeast viability based off production date | `yeast-viability --pd <Production date> --cc <Cell count> --f <Date format>`
 
 This list will expand as ideas and suggestions come in.
 

--- a/rustybeer-cli/Cargo.toml
+++ b/rustybeer-cli/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 rustybeer = { version = "0.1.0", path = "../rustybeer"}
 rustybeer-util = { version = "0.1.0", path = "../rustybeer-util"}
 structopt = "0.3.20"
+chrono = "0.4"
 
 [[bin]]
 name = "rustybeer"

--- a/rustybeer-cli/src/commands/mod.rs
+++ b/rustybeer-cli/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod diluting;
 pub mod num_bottles;
 pub mod priming;
 pub mod sg_correction;
+pub mod yeast_viability;

--- a/rustybeer-cli/src/commands/yeast_viability.rs
+++ b/rustybeer-cli/src/commands/yeast_viability.rs
@@ -1,0 +1,43 @@
+use chrono::format::ParseError;
+use chrono::{Duration, Local, NaiveDate, NaiveDateTime, NaiveTime};
+use rustybeer::calculators::yeast_viability::{calculate_cc, calculate_yv};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "abv", author = "Philip Golovin")]
+/// Estimates yeast viability based off production date
+pub struct YeastViabilityOptions {
+    #[structopt(short, long)]
+    /// Production date
+    pd: String,
+
+    #[structopt(short, long)]
+    /// Cell count
+    cc: Option<f32>,
+
+    #[structopt(short, long)]
+    /// Date format (default: "%d/%m/%Y")
+    f: Option<String>,
+}
+
+fn parse_date(date: String, format: String) -> Result<NaiveDateTime, ParseError> {
+    let t = NaiveTime::from_hms(0, 0, 0);
+    let date_only = NaiveDate::parse_from_str(&date, &format)?.and_time(t);
+    Ok(date_only)
+}
+
+pub fn calculate_and_print(yv_options: YeastViabilityOptions) {
+    let mut format = String::from("%d/%m/%Y");
+    if let Some(f) = yv_options.f {
+        format = f;
+    }
+    if let Ok(date) = parse_date(yv_options.pd, format) {
+        let days = (Local::now().timestamp() - date.timestamp()) / Duration::days(1).num_seconds();
+        println!("Yeast viability: {:.3}%", calculate_yv(days as f32));
+        if let Some(cc) = yv_options.cc {
+            println!("Cell count: {:.3}", calculate_cc(cc, days as f32))
+        }
+    } else {
+        println!("Date is invalid.");
+    }
+}

--- a/rustybeer-cli/src/main.rs
+++ b/rustybeer-cli/src/main.rs
@@ -15,6 +15,7 @@ pub enum RustyBeer {
     NumBottles(commands::num_bottles::NumBottlesOptions),
     Priming(commands::priming::PrimingOptions),
     SgCorrection(commands::sg_correction::SgCorrectionOptions),
+    YeastViability(commands::yeast_viability::YeastViabilityOptions),
 }
 
 fn main() -> Result<()> {
@@ -29,6 +30,7 @@ fn main() -> Result<()> {
         RustyBeer::NumBottles(opts) => commands::num_bottles::calculate_and_print(opts),
         RustyBeer::Priming(opts) => commands::priming::calculate_and_print(opts),
         RustyBeer::SgCorrection(opts) => commands::sg_correction::calculate_and_print(opts),
+        RustyBeer::YeastViability(opts) => commands::yeast_viability::calculate_and_print(opts),
     }
 
     Ok(())

--- a/rustybeer/src/calculators/mod.rs
+++ b/rustybeer/src/calculators/mod.rs
@@ -6,6 +6,7 @@ pub mod ibu;
 pub mod num_bottles;
 pub mod priming;
 pub mod sg_correction;
+pub mod yeast_viability;
 
 #[cfg(test)]
 mod test_vectors;

--- a/rustybeer/src/calculators/yeast_viability.rs
+++ b/rustybeer/src/calculators/yeast_viability.rs
@@ -1,0 +1,16 @@
+//! A calculator used to estimate
+//! yeast viability
+
+pub fn calculate_yv(days: f32) -> f32 {
+    let n_of_days = if days > 0.0 { days } else { 0.0 };
+    let res = 97.0 - (0.7 * n_of_days);
+    if res > 0.0 {
+        res
+    } else {
+        0.0
+    }
+}
+
+pub fn calculate_cc(cc: f32, days: f32) -> f32 {
+    cc * (calculate_yv(days) / 100.0)
+}

--- a/rustybeer/src/calculators/yeast_viability.rs
+++ b/rustybeer/src/calculators/yeast_viability.rs
@@ -3,12 +3,7 @@
 
 pub fn calculate_yv(days: f32) -> f32 {
     let n_of_days = if days > 0.0 { days } else { 0.0 };
-    let res = 97.0 - (0.7 * n_of_days);
-    if res > 0.0 {
-        res
-    } else {
-        0.0
-    }
+    97.0 * ((2.72_f32).powf(-0.008 * n_of_days))
 }
 
 pub fn calculate_cc(cc: f32, days: f32) -> f32 {


### PR DESCRIPTION
Closes #55 

Adds the `yeast-viability` command and provides the following options:
```
-c, --cc <cc>    Cell count
-f, --f <f>      Date format (default: "%d/%m/%Y")
-p, --pd <pd>    Production date
```

`-p, --pd` are required

usage:
```
$ rustybeer yeast-viability -p 2020/10/20 -f %Y/%m/%d -c 374.23
Yeast viability: 90.257%
Cell count: 337.770
```

The date format option supports the following specifiers for dates: https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html