### PR TITLE
refactor: hops to not publish list of hops

### DIFF
--- a/rustybeer-cli/src/commands/hops.rs
+++ b/rustybeer-cli/src/commands/hops.rs
@@ -1,4 +1,4 @@
-pub use rustybeer::hops::{Criteria, Hop, HOPS};
+pub use rustybeer::hops::{get_hops, Criteria, Hop};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -40,7 +40,7 @@ pub fn calculate_and_print(hop_options: HopOptions) {
         substituted: hop_options.substituted,
     };
 
-    let resp: Vec<&Hop> = HOPS.iter().filter(|hop| criteria.matches(hop)).collect();
+    let resp = get_hops(Some(criteria));
 
     if resp.is_empty() {
         println!("Could not find any hops matching criteria");

--- a/rustybeer-server/src/handlers/hops.rs
+++ b/rustybeer-server/src/handlers/hops.rs
@@ -1,4 +1,4 @@
-pub use rustybeer::hops::{Criteria, Hop, HOPS};
+pub use rustybeer::hops::{get_hops, Criteria, Hop};
 use rweb::*;
 use serde::{Deserialize, Serialize};
 
@@ -81,9 +81,8 @@ pub fn search(q: Query<HopQuery>) -> Json<Vec<HopResponse>> {
         substituted: query.substituted,
     };
 
-    let resp: Vec<HopResponse> = HOPS
+    let resp: Vec<HopResponse> = get_hops(Some(criteria))
         .iter()
-        .filter(|hop| criteria.matches(hop))
         .map(|hop| HopResponse::from_hop(&hop))
         .collect();
 

--- a/rustybeer/src/hops.rs
+++ b/rustybeer/src/hops.rs
@@ -21,6 +21,7 @@ pub struct Hop {
 }
 
 const HOPS_JSON: &str = include_str!("json/hops.json");
+static HOPS: Lazy<Vec<Hop>> = Lazy::new(|| serde_json::from_str(HOPS_JSON).unwrap());
 
 fn percentage_to_float<'de, D>(deserializer: D) -> Result<f64, D::Error>
 where
@@ -36,7 +37,10 @@ impl Hop {
     }
 }
 
-pub static HOPS: Lazy<Vec<Hop>> = Lazy::new(|| serde_json::from_str(HOPS_JSON).unwrap());
+pub fn get_hops(criteria: Option<Criteria>) -> Vec<&'static Hop> {
+    let crit = criteria.unwrap_or_default();
+    HOPS.iter().filter(|hop| crit.matches(hop)).collect()
+}
 
 /// Criteria for selecting a hop.
 ///


### PR DESCRIPTION
Introduce get_hops functionality instead. Relates to #111